### PR TITLE
Frontend: controlled score inputs, stronger form validation, realtime status and UI polish

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,73 +1,28 @@
-# React + TypeScript + Vite
+# Frontend (React + TypeScript + Vite)
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This directory contains the tournament UI used by both organizers and players.
 
-Currently, two official plugins are available:
+## Main usability behaviors
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Responsive top navigation with direct access to **Dashboard**, **Join**, and latest **Standings** link (when available in local storage).
+- Client-side validation for creating tournaments and joining tournaments.
+- Controlled score inputs in the admin round view for safer score reporting.
+- Tournament live view includes a websocket connection badge (`Connected`, `Reconnecting...`, `Connecting...`).
 
-## React Compiler
+## Commands
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+From this folder:
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm install
+npm run dev
+npm run test -- --run
+npm run lint
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Or from repository root:
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm --prefix frontend test -- --run
+npm --prefix frontend run lint
 ```

--- a/frontend/src/components/AdminDashboard.tsx
+++ b/frontend/src/components/AdminDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { config } from '../config';
 import ParticipantList from './ParticipantList';
@@ -39,6 +39,7 @@ export default function AdminDashboard() {
   const [events, setEvents] = useState<ActivityEvent[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [scoreInputs, setScoreInputs] = useState<Record<number, { p1: number; p2: number }>>({});
 
   useEffect(() => {
     if (!tournament) {
@@ -47,41 +48,46 @@ export default function AdminDashboard() {
   }, [tournament]);
 
   useEffect(() => {
-    if (tournament) {
-      fetchMatches();
-      fetchParticipants();
-      const ws = new WebSocket(`${config.wsUrl}/ws/${tournament.code}`);
-      ws.onmessage = (event) => {
-        const message = JSON.parse(event.data);
+    if (!tournament) return;
 
-        // Update matches and participants for UI state
-        if (message.event === 'participant_joined' || message.event === 'participant_removed' || message.event === 'match_reported' || message.event === 'pairings_generated') {
-          fetchMatches();
-          fetchParticipants();
-          fetchTournament(); // Refresh tournament to get new status
-        }
+    fetchMatches();
+    fetchParticipants();
 
-        // Add to activity log
-        if (message.event === 'participant_joined') {
-          const newEvent: ActivityEvent = {
-            id: Math.random().toString(36).substr(2, 9),
-            type: message.event,
-            message: `${message.data.name} joined the tournament.`,
-            timestamp: message.data.timestamp || new Date().toISOString()
-          };
-          setEvents(prev => [...prev, newEvent]);
-        } else if (message.event === 'match_reported') {
-          const newEvent: ActivityEvent = {
-            id: Math.random().toString(36).substr(2, 9),
-            type: message.event,
-            message: `Match results reported.`,
-            timestamp: new Date().toISOString()
-          };
-          setEvents(prev => [...prev, newEvent]);
-        }
-      };
-      return () => ws.close();
-    }
+    const ws = new WebSocket(`${config.wsUrl}/ws/${tournament.code}`);
+    ws.onmessage = (event) => {
+      const message = JSON.parse(event.data);
+
+      if (
+        message.event === 'participant_joined'
+        || message.event === 'participant_removed'
+        || message.event === 'match_reported'
+        || message.event === 'pairings_generated'
+      ) {
+        fetchMatches();
+        fetchParticipants();
+        fetchTournament();
+      }
+
+      if (message.event === 'participant_joined') {
+        const newEvent: ActivityEvent = {
+          id: Math.random().toString(36).substr(2, 9),
+          type: message.event,
+          message: `${message.data.name} joined the tournament.`,
+          timestamp: message.data.timestamp || new Date().toISOString(),
+        };
+        setEvents((prev) => [...prev, newEvent]);
+      } else if (message.event === 'match_reported') {
+        const newEvent: ActivityEvent = {
+          id: Math.random().toString(36).substr(2, 9),
+          type: message.event,
+          message: 'Match results reported.',
+          timestamp: new Date().toISOString(),
+        };
+        setEvents((prev) => [...prev, newEvent]);
+      }
+    };
+
+    return () => ws.close();
   }, [tournament]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const fetchMatches = async () => {
@@ -125,6 +131,13 @@ export default function AdminDashboard() {
 
   const handleCreateTournament = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    const safeRounds = Number.isFinite(rounds) ? Math.min(10, Math.max(1, rounds)) : 3;
+    if (!name.trim()) {
+      setError('Please provide a tournament name.');
+      return;
+    }
+
     setLoading(true);
     setError(null);
 
@@ -134,7 +147,7 @@ export default function AdminDashboard() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ name, rounds }),
+        body: JSON.stringify({ name: name.trim(), rounds: safeRounds }),
       });
 
       if (!response.ok) {
@@ -170,12 +183,13 @@ export default function AdminDashboard() {
     }
   };
 
-  const reportResult = async (matchId: number, p1Score: number, p2Score: number) => {
+  const reportResult = async (matchId: number) => {
+    const selectedScore = scoreInputs[matchId] ?? { p1: 0, p2: 0 };
     try {
       const response = await fetch(`${config.apiUrl}/matches/${matchId}/report`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ player1_score: p1Score, player2_score: p2Score }),
+        body: JSON.stringify({ player1_score: selectedScore.p1, player2_score: selectedScore.p2 }),
       });
       if (!response.ok) throw new Error('Failed to report result');
       await fetchMatches();
@@ -184,15 +198,26 @@ export default function AdminDashboard() {
     }
   };
 
+  const handleScoreChange = (matchId: number, player: 'p1' | 'p2', value: string) => {
+    const parsedValue = Math.max(0, Number.parseInt(value, 10) || 0);
+    setScoreInputs((prev) => ({
+      ...prev,
+      [matchId]: {
+        p1: player === 'p1' ? parsedValue : (prev[matchId]?.p1 ?? 0),
+        p2: player === 'p2' ? parsedValue : (prev[matchId]?.p2 ?? 0),
+      },
+    }));
+  };
+
   if (tournament) {
-    const currentRound = matches.length > 0 ? Math.max(...matches.map(m => m.round_number)) : 0;
-    const roundMatches = matches.filter(m => m.round_number === currentRound);
-    const allCompleted = roundMatches.every(m => m.is_completed);
+    const currentRound = matches.length > 0 ? Math.max(...matches.map((m) => m.round_number)) : 0;
+    const roundMatches = matches.filter((m) => m.round_number === currentRound);
+    const allCompleted = roundMatches.every((m) => m.is_completed);
     const isTournamentFinished = tournament.status === 'COMPLETED';
 
     const getPlayerName = (id: number | null) => {
       if (id === null) return '-';
-      const player = participants.find(p => p.id === id);
+      const player = participants.find((p) => p.id === id);
       return player ? player.name : `Player ${id}`;
     };
 
@@ -202,8 +227,7 @@ export default function AdminDashboard() {
         if (response.ok) {
           const standings = await response.json();
           const summary = standings.map((s: { rank: number; name: string; points: number; wins: number; losses: number; draws: number }) =>
-            `${s.rank}. ${s.name} (${s.points} pts, ${s.wins}-${s.losses}-${s.draws})`
-          ).join('\n');
+            `${s.rank}. ${s.name} (${s.points} pts, ${s.wins}-${s.losses}-${s.draws})`).join('\n');
 
           const blob = new Blob([summary], { type: 'text/plain' });
           const url = URL.createObjectURL(blob);
@@ -267,7 +291,7 @@ export default function AdminDashboard() {
                 {roundMatches.length === 0 ? (
                   <p className="text-gray-400 italic">No matches generated yet. Start the round to begin.</p>
                 ) : (
-                  roundMatches.map(match => (
+                  roundMatches.map((match) => (
                     <div key={match.id} className="bg-white p-6 rounded-2xl shadow-sm border border-gray-100 flex flex-col space-y-4">
                       <div className="flex justify-between items-center border-b border-gray-50 pb-2">
                         <span className="text-[10px] font-bold text-gray-400 uppercase tracking-widest">Table {match.table_number || '?'}</span>
@@ -286,15 +310,25 @@ export default function AdminDashboard() {
                           </div>
                         ) : (
                           <div className="flex-1 flex items-center justify-center space-x-2 px-4">
-                            <input type="number" id={`p1-${match.id}`} className="w-16 p-2 border rounded text-center font-bold" defaultValue={0} />
+                            <input
+                              type="number"
+                              min={0}
+                              className="w-16 p-2 border rounded text-center font-bold"
+                              value={scoreInputs[match.id]?.p1 ?? 0}
+                              onChange={(e) => handleScoreChange(match.id, 'p1', e.target.value)}
+                              aria-label={`Score for ${getPlayerName(match.player1_id)}`}
+                            />
                             <span className="text-gray-300">-</span>
-                            <input type="number" id={`p2-${match.id}`} className="w-16 p-2 border rounded text-center font-bold" defaultValue={0} />
+                            <input
+                              type="number"
+                              min={0}
+                              className="w-16 p-2 border rounded text-center font-bold"
+                              value={scoreInputs[match.id]?.p2 ?? 0}
+                              onChange={(e) => handleScoreChange(match.id, 'p2', e.target.value)}
+                              aria-label={`Score for ${getPlayerName(match.player2_id)}`}
+                            />
                             <button
-                              onClick={() => {
-                                const s1 = (document.getElementById(`p1-${match.id}`) as HTMLInputElement).value;
-                                const s2 = (document.getElementById(`p2-${match.id}`) as HTMLInputElement).value;
-                                reportResult(match.id, parseInt(s1), parseInt(s2));
-                              }}
+                              onClick={() => reportResult(match.id)}
                               className="ml-4 px-4 py-2 bg-gray-800 text-white text-sm font-bold rounded-lg hover:bg-black transition"
                             >
                               Report
@@ -324,21 +358,25 @@ export default function AdminDashboard() {
     );
   }
 
+  const isRoundsValid = Number.isFinite(rounds) && rounds >= 1 && rounds <= 10;
+  const isFormValid = name.trim().length > 0 && isRoundsValid;
+
   return (
     <div className="flex flex-col items-center justify-center min-h-screen p-4 bg-gray-50">
       <h1 className="text-3xl font-bold text-blue-600 mb-6 uppercase tracking-wider">Admin Dashboard</h1>
       <div className="bg-white p-8 rounded-xl shadow-lg w-full max-w-md border border-gray-100">
         <h2 className="text-xl font-semibold mb-6 text-gray-800">Create Tournament</h2>
-        <form onSubmit={handleCreateTournament} className="space-y-5">
+        <form onSubmit={handleCreateTournament} className="space-y-5" noValidate>
           <div>
             <label htmlFor="tournament-name" className="block text-sm font-medium text-gray-700 mb-1">Tournament Name</label>
             <input id="tournament-name" type="text" required value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Swiss Open #1" className="w-full p-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 transition outline-none" />
           </div>
           <div>
             <label htmlFor="rounds-count" className="block text-sm font-medium text-gray-700 mb-1">Number of Rounds</label>
-            <input id="rounds-count" type="number" min="1" max="10" value={rounds} onChange={(e) => setRounds(parseInt(e.target.value))} className="w-full p-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 transition outline-none" />
+            <input id="rounds-count" type="number" min="1" max="10" value={rounds} onChange={(e) => setRounds(Number.parseInt(e.target.value, 10))} className="w-full p-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 transition outline-none" />
+            {!isRoundsValid && <p className="text-xs text-red-600 mt-1">Rounds must be between 1 and 10.</p>}
           </div>
-          <button type="submit" disabled={loading} className={`w-full py-3 px-4 bg-blue-600 text-white font-bold rounded-lg transition ${loading ? 'opacity-50' : 'hover:bg-blue-700 shadow-md'}`}>
+          <button type="submit" disabled={loading || !isFormValid} className={`w-full py-3 px-4 bg-blue-600 text-white font-bold rounded-lg transition ${(loading || !isFormValid) ? 'opacity-50 cursor-not-allowed' : 'hover:bg-blue-700 shadow-md'}`}>
             {loading ? 'Creating...' : 'Create New Tournament'}
           </button>
         </form>

--- a/frontend/src/components/NavigationBar.tsx
+++ b/frontend/src/components/NavigationBar.tsx
@@ -5,20 +5,17 @@ const NavigationBar: React.FC = () => {
   const lastCode = localStorage.getItem('last_tournament_code');
 
   return (
-    <nav className="bg-indigo-600 text-white shadow-md p-4 flex justify-between items-center">
-      <div className="flex items-center space-x-6">
+    <nav className="bg-indigo-600 text-white shadow-md p-4 flex flex-wrap justify-between items-center gap-3">
+      <div className="flex items-center space-x-4 sm:space-x-6">
         <Link to="/" className="text-xl font-bold hover:text-indigo-100 transition">TCG Matchmaking</Link>
 
-        <div className="hidden sm:flex items-center space-x-4 border-l border-indigo-500 pl-6">
+        <div className="flex items-center space-x-3 sm:space-x-4 border-l border-indigo-500 pl-4 sm:pl-6">
           <Link to="/admin" className="text-sm font-medium hover:text-indigo-100 transition">Dashboard</Link>
+          <Link to="/join" className="text-sm font-medium hover:text-indigo-100 transition">Join</Link>
           {lastCode && (
             <Link to={`/${lastCode}`} target="_blank" className="text-sm font-medium hover:text-indigo-100 transition">Standings</Link>
           )}
         </div>
-      </div>
-
-      <div className="flex items-center space-x-4">
-        {/* Navigation links could go here if needed in the future */}
       </div>
     </nav>
   );

--- a/frontend/src/components/ParticipantJoin.test.tsx
+++ b/frontend/src/components/ParticipantJoin.test.tsx
@@ -80,7 +80,7 @@ describe('ParticipantJoin', () => {
     );
 
     fireEvent.change(screen.getByPlaceholderText(/e.g. Ash Ketchum/i), { target: { value: 'Ash' } });
-    fireEvent.change(screen.getByPlaceholderText(/e.g. ABCDEF/i), { target: { value: 'WRONG' } });
+    fireEvent.change(screen.getByPlaceholderText(/e.g. ABCDEF/i), { target: { value: 'WRONG1' } });
     fireEvent.click(screen.getByRole('button', { name: /Join Tournament/i }));
 
     await waitFor(() => {

--- a/frontend/src/components/ParticipantJoin.tsx
+++ b/frontend/src/components/ParticipantJoin.tsx
@@ -1,6 +1,8 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { config } from '../config';
+
+const TOURNAMENT_CODE_LENGTH = 6;
 
 export default function ParticipantJoin() {
   const [name, setName] = useState('');
@@ -9,18 +11,34 @@ export default function ParticipantJoin() {
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
 
+  const trimmedName = name.trim();
+  const normalizedCode = code.trim().toUpperCase();
+  const codeIsValid = /^[A-Z0-9]{6}$/.test(normalizedCode);
+  const isFormValid = trimmedName.length > 1 && codeIsValid;
+
+  const helperText = useMemo(() => {
+    if (!code) return `Tournament code must be ${TOURNAMENT_CODE_LENGTH} letters or numbers.`;
+    if (!codeIsValid) return `Enter exactly ${TOURNAMENT_CODE_LENGTH} letters or numbers.`;
+    return 'Code looks good.';
+  }, [code, codeIsValid]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!isFormValid) {
+      setError('Please provide a valid name and tournament code.');
+      return;
+    }
+
     setLoading(true);
     setError(null);
 
     try {
-      const response = await fetch(`${config.apiUrl}/tournaments/${code.toUpperCase()}/join`, {
+      const response = await fetch(`${config.apiUrl}/tournaments/${normalizedCode}/join`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ name }),
+        body: JSON.stringify({ name: trimmedName }),
       });
 
       if (!response.ok) {
@@ -29,11 +47,10 @@ export default function ParticipantJoin() {
       }
 
       const data = await response.json();
-      localStorage.setItem(`participant_id_${code.toUpperCase()}`, data.id.toString());
-      localStorage.setItem('last_tournament_code', code.toUpperCase());
+      localStorage.setItem(`participant_id_${normalizedCode}`, data.id.toString());
+      localStorage.setItem('last_tournament_code', normalizedCode);
 
-      // Redirect to the tournament view for the specific code
-      navigate(`/tournament/${code.toUpperCase()}`);
+      navigate(`/tournament/${normalizedCode}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An unexpected error occurred');
     } finally {
@@ -48,7 +65,7 @@ export default function ParticipantJoin() {
       <div className="bg-white p-8 rounded-xl shadow-lg w-full max-w-md border border-gray-100">
         <h2 className="text-xl font-semibold mb-6 text-gray-800">Enter Details</h2>
 
-        <form onSubmit={handleSubmit} className="space-y-5">
+        <form onSubmit={handleSubmit} className="space-y-5" noValidate>
           <div>
             <label htmlFor="player-name" className="block text-sm font-medium text-gray-700 mb-1">Your Name</label>
             <input
@@ -72,21 +89,22 @@ export default function ParticipantJoin() {
               onChange={(e) => setCode(e.target.value.toUpperCase())}
               placeholder="e.g. ABCDEF"
               className="w-full p-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500 transition outline-none font-mono uppercase text-center text-lg tracking-widest"
-              maxLength={6}
+              maxLength={TOURNAMENT_CODE_LENGTH}
             />
+            <p className={`mt-1 text-xs ${codeIsValid ? 'text-green-600' : 'text-gray-500'}`}>{helperText}</p>
           </div>
 
           <button
             type="submit"
-            disabled={loading}
-            className={`w-full py-3 px-4 bg-green-600 text-white font-bold rounded-lg transition ${loading ? 'opacity-50 cursor-not-allowed' : 'hover:bg-green-700 shadow-md hover:shadow-lg active:scale-[0.98]'}`}
+            disabled={loading || !isFormValid}
+            className={`w-full py-3 px-4 bg-green-600 text-white font-bold rounded-lg transition ${(loading || !isFormValid) ? 'opacity-50 cursor-not-allowed' : 'hover:bg-green-700 shadow-md hover:shadow-lg active:scale-[0.98]'}`}
           >
             {loading ? 'Joining...' : 'Join Tournament'}
           </button>
         </form>
 
         {error && (
-          <div className="mt-6 p-3 bg-red-50 border border-red-200 text-red-600 rounded-lg text-sm">
+          <div className="mt-6 p-3 bg-red-50 border border-red-200 text-red-600 rounded-lg text-sm" role="alert">
             {error}
           </div>
         )}

--- a/frontend/src/components/ParticipantList.tsx
+++ b/frontend/src/components/ParticipantList.tsx
@@ -85,7 +85,7 @@ export default function ParticipantList({ tournamentCode, participants, onUpdate
           </button>
         </form>
 
-        {error && <div className="text-xs text-red-500 font-medium">{error}</div>}
+        {error && <div className="text-xs text-red-500 font-medium" role="alert">{error}</div>}
       </div>
 
       <div className="flex-1 overflow-y-auto px-6 pb-6">
@@ -101,8 +101,8 @@ export default function ParticipantList({ tournamentCode, participants, onUpdate
                 </div>
                 <button
                   onClick={() => handleRemoveParticipant(p.id)}
-                  className="w-8 h-8 flex items-center justify-center text-gray-300 hover:text-red-500 hover:bg-red-50 rounded-full transition opacity-0 group-hover:opacity-100"
-                  aria-label="Remove"
+                  className="w-8 h-8 flex items-center justify-center text-red-400 hover:text-red-600 hover:bg-red-50 rounded-full transition opacity-100 md:opacity-80 md:group-hover:opacity-100"
+                  aria-label={`Remove ${p.name}`}
                 >
                   &times;
                 </button>

--- a/frontend/src/components/TournamentView.tsx
+++ b/frontend/src/components/TournamentView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { config } from '../config';
 
@@ -31,6 +31,8 @@ interface PotentialPairing {
   points: number;
 }
 
+type SocketStatus = 'connecting' | 'connected' | 'reconnecting' | 'offline';
+
 export default function TournamentView() {
   const { code } = useParams<{ code: string }>();
   const [matches, setMatches] = useState<Match[]>([]);
@@ -38,30 +40,57 @@ export default function TournamentView() {
   const [potentialPairings, setPotentialPairings] = useState<PotentialPairing[]>([]);
   const [activeTab, setActiveTab] = useState<'pairings' | 'standings'>('pairings');
   const [loading, setLoading] = useState(true);
+  const [socketStatus, setSocketStatus] = useState<SocketStatus>('connecting');
 
   const participantIdStr = localStorage.getItem(`participant_id_${code}`);
-  const participantId = participantIdStr ? parseInt(participantIdStr) : null;
+  const participantId = participantIdStr ? Number.parseInt(participantIdStr, 10) : null;
 
   useEffect(() => {
+    if (!code) return;
+
     fetchData();
 
-    const ws = new WebSocket(`${config.wsUrl}/ws/${code}`);
+    let ws: WebSocket | null = null;
+    let reconnectTimer: number | null = null;
 
-    ws.onmessage = (event) => {
-      const message = JSON.parse(event.data);
-      if (message.event === 'pairings_generated' || message.event === 'match_reported' || message.event === 'participant_joined') {
-        fetchData();
-      }
+    const connect = () => {
+      setSocketStatus((prev) => (prev === 'connected' ? prev : 'connecting'));
+      ws = new WebSocket(`${config.wsUrl}/ws/${code}`);
+
+      ws.onopen = () => {
+        setSocketStatus('connected');
+      };
+
+      ws.onmessage = (event) => {
+        const message = JSON.parse(event.data);
+        if (message.event === 'pairings_generated' || message.event === 'match_reported' || message.event === 'participant_joined') {
+          fetchData();
+        }
+      };
+
+      ws.onclose = () => {
+        setSocketStatus('reconnecting');
+        reconnectTimer = window.setTimeout(() => connect(), 1500);
+      };
+
+      ws.onerror = () => {
+        setSocketStatus('offline');
+      };
     };
 
-    return () => ws.close();
+    connect();
+
+    return () => {
+      if (reconnectTimer) window.clearTimeout(reconnectTimer);
+      ws?.close();
+    };
   }, [code]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const fetchData = async () => {
     try {
       const [matchesRes, standingsRes] = await Promise.all([
         fetch(`${config.apiUrl}/tournaments/${code}/matches`),
-        fetch(`${config.apiUrl}/tournaments/${code}/standings`)
+        fetch(`${config.apiUrl}/tournaments/${code}/standings`),
       ]);
 
       if (matchesRes.ok) {
@@ -90,14 +119,20 @@ export default function TournamentView() {
 
   if (loading) return <div className="p-8 text-center font-bold text-gray-500 uppercase tracking-widest animate-pulse">Loading tournament...</div>;
 
-  const rounds = [...new Set(matches.map(m => m.round_number))].sort((a, b) => b - a);
-  const myStanding = standings.find(s => s.id === participantId);
+  const rounds = [...new Set(matches.map((m) => m.round_number))].sort((a, b) => b - a);
+  const myStanding = standings.find((s) => s.id === participantId);
 
   const getPlayerName = (id: number | null) => {
     if (id === null) return '-';
-    const player = standings.find(s => s.id === id);
+    const player = standings.find((s) => s.id === id);
     return player ? player.name : `Player ${id}`;
   };
+
+  const socketStatusClass = socketStatus === 'connected'
+    ? 'bg-green-100 text-green-700'
+    : socketStatus === 'reconnecting'
+      ? 'bg-yellow-100 text-yellow-700'
+      : 'bg-gray-100 text-gray-700';
 
   return (
     <div className="max-w-4xl mx-auto p-4 sm:p-8 space-y-8">
@@ -106,19 +141,25 @@ export default function TournamentView() {
           Tournament <span className="text-blue-600">#{code}</span>
         </h1>
 
-        <div className="flex bg-gray-100 p-1 rounded-xl">
-          <button
-            onClick={() => setActiveTab('pairings')}
-            className={`px-6 py-2 rounded-lg text-sm font-bold transition ${activeTab === 'pairings' ? 'bg-white text-gray-800 shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
-          >
-            Pairings
-          </button>
-          <button
-            onClick={() => setActiveTab('standings')}
-            className={`px-6 py-2 rounded-lg text-sm font-bold transition ${activeTab === 'standings' ? 'bg-white text-gray-800 shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
-          >
-            Standings
-          </button>
+        <div className="flex items-center gap-3">
+          <span className={`text-xs font-bold px-3 py-1 rounded-full ${socketStatusClass}`}>
+            {socketStatus === 'connected' ? 'Connected' : socketStatus === 'reconnecting' ? 'Reconnecting...' : 'Connecting...'}
+          </span>
+
+          <div className="flex bg-gray-100 p-1 rounded-xl">
+            <button
+              onClick={() => setActiveTab('pairings')}
+              className={`px-6 py-2 rounded-lg text-sm font-bold transition ${activeTab === 'pairings' ? 'bg-white text-gray-800 shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
+            >
+              Pairings
+            </button>
+            <button
+              onClick={() => setActiveTab('standings')}
+              className={`px-6 py-2 rounded-lg text-sm font-bold transition ${activeTab === 'standings' ? 'bg-white text-gray-800 shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
+            >
+              Standings
+            </button>
+          </div>
         </div>
       </div>
 
@@ -151,7 +192,7 @@ export default function TournamentView() {
             <div>
               <div className="text-blue-200 text-[10px] font-bold uppercase tracking-widest">Possible Opponents</div>
               <div className="text-xs font-medium mt-1 truncate">
-                {potentialPairings.length > 0 ? potentialPairings.map(p => p.name).join(', ') : 'None'}
+                {potentialPairings.length > 0 ? potentialPairings.map((p) => p.name).join(', ') : 'None'}
               </div>
             </div>
           </div>
@@ -165,14 +206,14 @@ export default function TournamentView() {
           </div>
         ) : (
           <div className="space-y-10">
-            {rounds.map(round => (
+            {rounds.map((round) => (
               <div key={round} className="animate-in fade-in slide-in-from-bottom-4 duration-500">
                 <h2 className="text-xl font-bold text-gray-700 mb-4 flex items-center">
                   <span className="bg-gray-800 text-white px-3 py-1 rounded-lg text-sm mr-3">Round {round}</span>
-                  <div className="flex-1 h-px bg-gray-200"></div>
+                  <div className="flex-1 h-px bg-gray-200" />
                 </h2>
                 <div className="grid gap-4 sm:grid-cols-2">
-                  {matches.filter(m => m.round_number === round).map(match => (
+                  {matches.filter((m) => m.round_number === round).map((match) => (
                     <div key={match.id} className={`p-5 rounded-2xl border transition-all ${match.is_completed ? 'bg-white border-gray-100 opacity-60 grayscale' : 'bg-white border-blue-100 shadow-sm hover:shadow-md'}`}>
                       <div className="flex justify-between items-center mb-4">
                         <span className="text-[10px] font-bold text-gray-400 uppercase tracking-[0.2em]">Table {match.table_number || '?'}</span>


### PR DESCRIPTION
### Motivation
- Improve admin and player UX by making score reporting safer, adding client-side validation, and surfacing realtime connection status. 
- Harden tournament join flow by normalizing and validating input to reduce backend errors and improve accessibility. 
- Provide quick developer instructions for running the frontend and tests from the `frontend` folder.

### Description
- Replace uncontrolled DOM score lookups in `AdminDashboard` with controlled inputs and `scoreInputs` state, add `handleScoreChange` and use it in `reportResult`. 
- Add client-side validation and sanitization for tournament creation (`safeRounds`, trimmed `name`, `isFormValid`) and disable the create button until the form is valid. 
- Refactor websocket setup in `AdminDashboard` and `TournamentView` to handle messaging more cleanly, add reconnect logic and a socket status badge in `TournamentView`. 
- Improve `ParticipantJoin` by normalizing tournament codes to uppercase, trimming names, adding a code validation helper and `isFormValid` checks, and persist normalized keys in `localStorage`. 
- Update `ParticipantList` and other components for better accessibility and UI polish (aria/role attributes, remove fragile DOM queries, tweak button styles and labels). 
- Update `NavigationBar` to be more responsive and expose `Join` and last-standings links, and refresh `frontend/README.md` with concise commands for dev, test and lint. 
- Minor TypeScript/JSX cleanups and safer number parsing across components (use `Number.parseInt` and explicit radix). 

### Testing
- Ran frontend unit tests including the updated `ParticipantJoin.test.tsx` under the frontend test suite with `npm --prefix frontend test -- --run`, and the tests passed. 
- Linted and ran basic dev checks with `npm --prefix frontend run lint` and `npm --prefix frontend run dev` during verification and no blocking errors were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa3d87d2e4832b833079a29d536b67)