### PR TITLE
Refactor standings layout: add mobile cards and desktop scroll affordances

### DIFF
--- a/frontend/src/components/AdminDashboard.test.tsx
+++ b/frontend/src/components/AdminDashboard.test.tsx
@@ -209,6 +209,7 @@ describe('AdminDashboard', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /Final Standings/i })).toBeInTheDocument();
+      expect(screen.getByText(/Scroll for more/i)).toBeInTheDocument();
     });
 
     const table = screen.getByRole('table');

--- a/frontend/src/components/AdminDashboard.tsx
+++ b/frontend/src/components/AdminDashboard.tsx
@@ -330,6 +330,20 @@ export default function AdminDashboard() {
     return ((wins + draws * 0.5) / total) * 100;
   };
 
+  const renderStandingPokemon = (standing: Participant, compact = false) => (
+    <div className="flex items-center space-x-2">
+      <div className="flex -space-x-2">
+        <PokemonSprite pokemonId={standing.pokemon_1} size={compact ? 'md' : 'sm'} />
+        <PokemonSprite pokemonId={standing.pokemon_2} size={compact ? 'md' : 'sm'} />
+      </div>
+      {!compact && (
+        <span className="text-xs text-gray-500 capitalize">
+          {pokemonMap[standing.pokemon_1 || ''] || ''} / {pokemonMap[standing.pokemon_2 || ''] || ''}
+        </span>
+      )}
+    </div>
+  );
+
   if (tournament) {
     const currentRound = matches.length > 0 ? Math.max(...matches.map((m) => m.round_number)) : 0;
     const roundMatches = matches.filter((m) => m.round_number === currentRound);
@@ -528,49 +542,103 @@ export default function AdminDashboard() {
                   <div className="p-6 border-b border-gray-50 flex justify-between items-center">
                     <h3 className="text-xl font-bold text-gray-800">{t('adminFinalStandings')}</h3>
                   </div>
-                  <div className="overflow-x-auto">
-                    <table className="w-full text-left">
-                      <thead>
-                        <tr className="bg-gray-50 text-gray-500 text-[10px] font-bold uppercase tracking-widest border-b border-gray-100">
-                          <th className="px-6 py-4 text-center">{t('adminRank')}</th>
-                          <th className="px-6 py-4">{t('adminPlayer')}</th>
-                          <th className="px-6 py-4">{t('adminPokemon')}</th>
-                          <th className="px-6 py-4">{t('adminPoints')}</th>
-                          <th className="px-6 py-4">{t('adminRecord')}</th>
-                          <th className="px-6 py-4 text-right">{t('adminWinPercent')}</th>
-                          <th className="px-6 py-4 text-right">{t('adminOMW')}</th>
-                        </tr>
-                      </thead>
-                      <tbody className="divide-y divide-gray-50">
-                        {standings.map((s) => (
-                          <tr key={s.id} className="hover:bg-blue-50/30 transition-colors">
-                            <td className="px-6 py-4 font-black text-gray-400 text-center">#{s.rank}</td>
-                            <td className="px-6 py-4">
-                              <span className="font-bold text-gray-800">{s.name}</span>
-                            </td>
-                            <td className="px-6 py-4">
-                              <div className="flex items-center space-x-2">
-                                <div className="flex -space-x-2">
-                                  <PokemonSprite pokemonId={s.pokemon_1} size="sm" />
-                                  <PokemonSprite pokemonId={s.pokemon_2} size="sm" />
-                                </div>
-                                <span className="text-xs text-gray-500 capitalize">
-                                  {pokemonMap[s.pokemon_1 || ''] || ''} / {pokemonMap[s.pokemon_2 || ''] || ''}
-                                </span>
-                              </div>
-                            </td>
-                            <td className="px-6 py-4 font-black text-blue-600">{s.points}</td>
-                            <td className="px-6 py-4 text-sm text-gray-500 font-medium">{s.wins}-{s.losses}-{s.draws}</td>
-                            <td className="px-6 py-4 text-right font-mono text-xs font-bold text-gray-400">
-                              {getWinPercentage(s.wins ?? 0, s.losses ?? 0, s.draws ?? 0).toFixed(1)}%
-                            </td>
-                            <td className="px-6 py-4 text-right font-mono text-xs font-bold text-gray-400">
-                              {((s.omw_percentage || 0) * 100).toFixed(1)}%
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
+                  <div className="space-y-4 p-4 sm:p-6">
+                    <div className="grid gap-4 md:hidden">
+                      {standings.map((s) => (
+                        <article key={s.id} className="rounded-3xl border border-gray-100 bg-white p-5 shadow-sm">
+                          <div className="flex items-start justify-between gap-4">
+                            <div>
+                              <div className="text-[10px] font-bold uppercase tracking-[0.2em] text-gray-400">{t('adminRank')}</div>
+                              <div className="mt-1 text-3xl font-black text-gray-800">#{s.rank}</div>
+                            </div>
+                            <div className="text-right">
+                              <div className="text-[10px] font-bold uppercase tracking-[0.2em] text-gray-400">{t('adminPoints')}</div>
+                              <div className="mt-1 text-2xl font-black text-blue-600">{s.points}</div>
+                            </div>
+                          </div>
+
+                          <div className="mt-4 flex items-start justify-between gap-4">
+                            <div className="min-w-0">
+                              <h4 className="truncate text-xl font-black text-gray-800">{s.name}</h4>
+                              <div className="mt-2">{renderStandingPokemon(s, true)}</div>
+                            </div>
+                          </div>
+
+                          <dl className="mt-5 grid grid-cols-3 gap-3 rounded-2xl border border-gray-100 bg-gray-50/80 p-4">
+                            <div>
+                              <dt className="text-[10px] font-bold uppercase tracking-widest text-gray-400">{t('adminRecord')}</dt>
+                              <dd className="mt-1 text-sm font-bold text-gray-700">{s.wins}-{s.losses}-{s.draws}</dd>
+                            </div>
+                            <div>
+                              <dt className="text-[10px] font-bold uppercase tracking-widest text-gray-400">{t('adminWinPercent')}</dt>
+                              <dd className="mt-1 text-sm font-bold text-gray-700">
+                                {getWinPercentage(s.wins ?? 0, s.losses ?? 0, s.draws ?? 0).toFixed(1)}%
+                              </dd>
+                            </div>
+                            <div>
+                              <dt className="text-[10px] font-bold uppercase tracking-widest text-gray-400">{t('adminOMW')}</dt>
+                              <dd className="mt-1 text-sm font-bold text-gray-700">{((s.omw_percentage || 0) * 100).toFixed(1)}%</dd>
+                            </div>
+                          </dl>
+                        </article>
+                      ))}
+                      {standings.length === 0 && (
+                        <div className="rounded-3xl border-2 border-dashed border-gray-200 bg-gray-50 px-6 py-12 text-center text-gray-400 italic">
+                          {t('tournamentNoParticipants')}
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="hidden md:block">
+                      <div className="mb-2 flex items-center justify-end px-1 text-[11px] font-semibold uppercase tracking-widest text-gray-400">
+                        <span>{t('commonScrollToSeeMore')}</span>
+                      </div>
+                      <div className="relative overflow-hidden rounded-2xl border border-gray-100">
+                        <div className="pointer-events-none absolute inset-y-0 left-0 z-20 w-6 bg-gradient-to-r from-white via-white/90 to-transparent" />
+                        <div className="pointer-events-none absolute inset-y-0 right-0 z-20 w-8 bg-gradient-to-l from-white via-white/90 to-transparent" />
+                        <div className="overflow-x-auto">
+                          <table className="min-w-full text-left">
+                            <thead>
+                              <tr className="bg-gray-50 text-gray-500 text-[10px] font-bold uppercase tracking-widest border-b border-gray-100">
+                                <th className="sticky left-0 z-10 bg-gray-50 px-6 py-4 text-center">{t('adminRank')}</th>
+                                <th className="px-6 py-4">{t('adminPlayer')}</th>
+                                <th className="px-6 py-4">{t('adminPokemon')}</th>
+                                <th className="px-6 py-4">{t('adminPoints')}</th>
+                                <th className="px-6 py-4">{t('adminRecord')}</th>
+                                <th className="px-6 py-4 text-right">{t('adminWinPercent')}</th>
+                                <th className="px-6 py-4 text-right">{t('adminOMW')}</th>
+                              </tr>
+                            </thead>
+                            <tbody className="divide-y divide-gray-50">
+                              {standings.map((s) => (
+                                <tr key={s.id} className="hover:bg-blue-50/30 transition-colors">
+                                  <td className="sticky left-0 bg-white px-6 py-4 font-black text-gray-400 text-center">#{s.rank}</td>
+                                  <td className="px-6 py-4">
+                                    <span className="font-bold text-gray-800">{s.name}</span>
+                                  </td>
+                                  <td className="px-6 py-4">
+                                    {renderStandingPokemon(s)}
+                                  </td>
+                                  <td className="px-6 py-4 font-black text-blue-600">{s.points}</td>
+                                  <td className="px-6 py-4 text-sm text-gray-500 font-medium">{s.wins}-{s.losses}-{s.draws}</td>
+                                  <td className="px-6 py-4 text-right font-mono text-xs font-bold text-gray-400">
+                                    {getWinPercentage(s.wins ?? 0, s.losses ?? 0, s.draws ?? 0).toFixed(1)}%
+                                  </td>
+                                  <td className="px-6 py-4 text-right font-mono text-xs font-bold text-gray-400">
+                                    {((s.omw_percentage || 0) * 100).toFixed(1)}%
+                                  </td>
+                                </tr>
+                              ))}
+                              {standings.length === 0 && (
+                                <tr>
+                                  <td colSpan={7} className="px-6 py-12 text-center text-gray-400 italic">{t('tournamentNoParticipants')}</td>
+                                </tr>
+                              )}
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/frontend/src/components/TournamentView.test.tsx
+++ b/frontend/src/components/TournamentView.test.tsx
@@ -118,6 +118,7 @@ describe('TournamentView', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getByText(/Scroll for more/i)).toBeInTheDocument();
       expect(screen.getAllByText('Alice').length).toBeGreaterThan(0);
       expect(screen.getAllByText('100.0%').length).toBeGreaterThan(0);
     });

--- a/frontend/src/components/TournamentView.tsx
+++ b/frontend/src/components/TournamentView.tsx
@@ -187,6 +187,19 @@ export default function TournamentView() {
     return ((wins + draws * 0.5) / total) * 100;
   };
 
+  const renderPokemonVisibility = (standing: Standing, compact = false) => {
+    if (tournamentCompleted) {
+      return (
+        <div className="flex -space-x-2">
+          <PokemonSprite pokemonId={standing.pokemon_1} size={compact ? 'md' : 'sm'} />
+          <PokemonSprite pokemonId={standing.pokemon_2} size={compact ? 'md' : 'sm'} />
+        </div>
+      );
+    }
+
+    return <span className="text-xs text-gray-400 italic">{t('tournamentHidden')}</span>;
+  };
+
   const renderPlayer = (id: number | null) => {
     if (id === null) return <span className="text-gray-400">-</span>;
     const player = standings.find((s) => s.id === id);
@@ -364,51 +377,126 @@ export default function TournamentView() {
           </div>
         )
       ) : (
-        <div className="bg-white rounded-3xl border border-gray-100 shadow-sm overflow-hidden animate-in fade-in duration-500">
-          <table className="w-full text-left border-collapse">
-            <thead>
-              <tr className="bg-gray-50 text-gray-500 text-[10px] font-bold uppercase tracking-widest border-b border-gray-100">
-                <th className="px-6 py-4">{t('tournamentRank')}</th>
-                <th className="px-6 py-4">{t('tournamentPlayer')}</th>
-                <th className="px-6 py-4">{t('tournamentPokemon')}</th>
-                <th className="px-6 py-4">{t('tournamentPoints')}</th>
-                <th className="px-6 py-4">{t('tournamentRecord')}</th>
-                <th className="px-6 py-4 text-right">{t('tournamentWinPercent')}</th>
-                <th className="px-6 py-4 text-right">{t('tournamentOMW')}</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-50">
-              {standings.map((s) => (
-                <tr key={s.id} className={`hover:bg-blue-50/30 transition-colors ${s.id === participantId ? 'bg-blue-50/50' : ''}`}>
-                  <td className="px-6 py-4 font-black text-gray-400">#{s.rank}</td>
-                  <td className="px-6 py-4">
-                    <div className="flex items-center space-x-3">
-                      <span className="font-bold text-gray-800">{s.name}</span>
-                    </div>
-                  </td>
-                  <td className="px-6 py-4">
-                    {tournamentCompleted ? (
-                      <div className="flex -space-x-2">
-                        <PokemonSprite pokemonId={s.pokemon_1} size="sm" />
-                        <PokemonSprite pokemonId={s.pokemon_2} size="sm" />
+        <div className="space-y-4 animate-in fade-in duration-500">
+          <div className="grid gap-4 sm:hidden">
+            {standings.map((s) => {
+              const isCurrentParticipant = s.id === participantId;
+              const winPercentage = getWinPercentage(s.wins, s.losses, s.draws).toFixed(1);
+
+              return (
+                <article
+                  key={s.id}
+                  className={`rounded-3xl border p-5 shadow-sm transition-all ${
+                    isCurrentParticipant
+                      ? 'border-blue-300 bg-gradient-to-br from-blue-600 via-blue-500 to-indigo-500 text-white shadow-xl shadow-blue-200 ring-2 ring-blue-200'
+                      : 'border-gray-100 bg-white'
+                  }`}
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <div className={`text-[10px] font-bold uppercase tracking-[0.2em] ${isCurrentParticipant ? 'text-blue-100' : 'text-gray-400'}`}>
+                        {t('tournamentRank')}
                       </div>
-                    ) : (
-                      <span className="text-xs text-gray-400 italic">{t('tournamentHidden')}</span>
+                      <div className={`mt-1 text-3xl font-black ${isCurrentParticipant ? 'text-white' : 'text-gray-800'}`}>#{s.rank}</div>
+                    </div>
+                    <div className="text-right">
+                      <div className={`text-[10px] font-bold uppercase tracking-[0.2em] ${isCurrentParticipant ? 'text-blue-100' : 'text-gray-400'}`}>
+                        {t('tournamentPoints')}
+                      </div>
+                      <div className={`mt-1 text-2xl font-black ${isCurrentParticipant ? 'text-white' : 'text-blue-600'}`}>{s.points}</div>
+                    </div>
+                  </div>
+
+                  <div className="mt-4 flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <h3 className={`truncate text-xl font-black ${isCurrentParticipant ? 'text-white' : 'text-gray-800'}`}>{s.name}</h3>
+                      {isCurrentParticipant && (
+                        <p className="mt-1 text-xs font-semibold uppercase tracking-[0.2em] text-blue-100">{t('tournamentMyStatus')}</p>
+                      )}
+                    </div>
+                    <div className="shrink-0">
+                      {renderPokemonVisibility(s, true)}
+                    </div>
+                  </div>
+
+                  <dl className={`mt-5 grid grid-cols-3 gap-3 rounded-2xl border p-4 ${isCurrentParticipant ? 'border-white/15 bg-white/10' : 'border-gray-100 bg-gray-50/80'}`}>
+                    <div>
+                      <dt className={`text-[10px] font-bold uppercase tracking-widest ${isCurrentParticipant ? 'text-blue-100' : 'text-gray-400'}`}>
+                        {t('tournamentRecord')}
+                      </dt>
+                      <dd className={`mt-1 text-sm font-bold ${isCurrentParticipant ? 'text-white' : 'text-gray-700'}`}>{s.wins}-{s.losses}-{s.draws}</dd>
+                    </div>
+                    <div>
+                      <dt className={`text-[10px] font-bold uppercase tracking-widest ${isCurrentParticipant ? 'text-blue-100' : 'text-gray-400'}`}>
+                        {t('tournamentWinPercent')}
+                      </dt>
+                      <dd className={`mt-1 text-sm font-bold ${isCurrentParticipant ? 'text-white' : 'text-gray-700'}`}>{winPercentage}%</dd>
+                    </div>
+                    <div>
+                      <dt className={`text-[10px] font-bold uppercase tracking-widest ${isCurrentParticipant ? 'text-blue-100' : 'text-gray-400'}`}>
+                        {t('tournamentOMW')}
+                      </dt>
+                      <dd className={`mt-1 text-sm font-bold ${isCurrentParticipant ? 'text-white' : 'text-gray-700'}`}>{(s.omw_percentage * 100).toFixed(1)}%</dd>
+                    </div>
+                  </dl>
+                </article>
+              );
+            })}
+            {standings.length === 0 && (
+              <div className="rounded-3xl border-2 border-dashed border-gray-200 bg-gray-50 px-6 py-12 text-center text-gray-400 italic">
+                {t('tournamentNoParticipants')}
+              </div>
+            )}
+          </div>
+
+          <div className="hidden sm:block">
+            <div className="mb-2 flex items-center justify-end px-1 text-[11px] font-semibold uppercase tracking-widest text-gray-400">
+              <span>{t('commonScrollToSeeMore')}</span>
+            </div>
+            <div className="relative overflow-hidden rounded-3xl border border-gray-100 bg-white shadow-sm">
+              <div className="pointer-events-none absolute inset-y-0 left-0 z-20 w-6 bg-gradient-to-r from-white via-white/90 to-transparent" />
+              <div className="pointer-events-none absolute inset-y-0 right-0 z-20 w-8 bg-gradient-to-l from-white via-white/90 to-transparent" />
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-left border-collapse">
+                  <thead>
+                    <tr className="bg-gray-50 text-gray-500 text-[10px] font-bold uppercase tracking-widest border-b border-gray-100">
+                      <th className="sticky left-0 z-10 bg-gray-50 px-6 py-4">{t('tournamentRank')}</th>
+                      <th className="px-6 py-4">{t('tournamentPlayer')}</th>
+                      <th className="px-6 py-4">{t('tournamentPokemon')}</th>
+                      <th className="px-6 py-4">{t('tournamentPoints')}</th>
+                      <th className="px-6 py-4">{t('tournamentRecord')}</th>
+                      <th className="px-6 py-4 text-right">{t('tournamentWinPercent')}</th>
+                      <th className="px-6 py-4 text-right">{t('tournamentOMW')}</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-50">
+                    {standings.map((s) => (
+                      <tr key={s.id} className={`hover:bg-blue-50/30 transition-colors ${s.id === participantId ? 'bg-blue-50/50' : ''}`}>
+                        <td className={`sticky left-0 px-6 py-4 font-black text-gray-400 ${s.id === participantId ? 'bg-blue-50/50' : 'bg-white'}`}>#{s.rank}</td>
+                        <td className="px-6 py-4">
+                          <div className="flex items-center space-x-3">
+                            <span className="font-bold text-gray-800">{s.name}</span>
+                          </div>
+                        </td>
+                        <td className="px-6 py-4">
+                          {renderPokemonVisibility(s)}
+                        </td>
+                        <td className="px-6 py-4 font-black text-blue-600">{s.points}</td>
+                        <td className="px-6 py-4 text-sm text-gray-500 font-medium">{s.wins}-{s.losses}-{s.draws}</td>
+                        <td className="px-6 py-4 text-right font-mono text-xs font-bold text-gray-400">{getWinPercentage(s.wins, s.losses, s.draws).toFixed(1)}%</td>
+                        <td className="px-6 py-4 text-right font-mono text-xs font-bold text-gray-400">{(s.omw_percentage * 100).toFixed(1)}%</td>
+                      </tr>
+                    ))}
+                    {standings.length === 0 && (
+                      <tr>
+                        <td colSpan={7} className="px-6 py-12 text-center text-gray-400 italic">{t('tournamentNoParticipants')}</td>
+                      </tr>
                     )}
-                  </td>
-                  <td className="px-6 py-4 font-black text-blue-600">{s.points}</td>
-                  <td className="px-6 py-4 text-sm text-gray-500 font-medium">{s.wins}-{s.losses}-{s.draws}</td>
-                  <td className="px-6 py-4 text-right font-mono text-xs font-bold text-gray-400">{getWinPercentage(s.wins, s.losses, s.draws).toFixed(1)}%</td>
-                  <td className="px-6 py-4 text-right font-mono text-xs font-bold text-gray-400">{(s.omw_percentage * 100).toFixed(1)}%</td>
-                </tr>
-              ))}
-              {standings.length === 0 && (
-                <tr>
-                  <td colSpan={7} className="px-6 py-12 text-center text-gray-400 italic">{t('tournamentNoParticipants')}</td>
-                </tr>
-              )}
-            </tbody>
-          </table>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -62,6 +62,7 @@ const MESSAGES = {
     commonNone: 'None',
     commonPlayerWithId: 'Player {id}',
     commonScoreForPlayer: 'Score for {name}',
+    commonScrollToSeeMore: 'Scroll for more',
 
     adminMatchReported: 'Match results reported.',
     adminProvideTournamentName: 'Please provide a tournament name.',
@@ -206,6 +207,7 @@ const MESSAGES = {
     commonNone: 'Nenhum',
     commonPlayerWithId: 'Jogador {id}',
     commonScoreForPlayer: 'Resultado de {name}',
+    commonScrollToSeeMore: 'Role para ver mais',
 
     adminMatchReported: 'Resultado de partida reportado.',
     adminProvideTournamentName: 'Informe o nome do torneio.',


### PR DESCRIPTION
### Motivation
- Improve the standings UI on small screens by surfacing the most important fields first (rank, player name, points, record, win %, OMW) while preserving the existing desktop table view and Pokémon visibility rules. 
- Make it easier for the current participant to find their standing by adding a stronger visual treatment on the public view. 
- Keep any remaining table views usable on narrow screens by adding clear horizontal-scroll affordances and a sticky first-column for rank.

### Description
- Added a mobile card rendering path for public standings in `frontend/src/components/TournamentView.tsx` that appears below `sm`, prioritizes rank, name, points, record, win %, and OMW, preserves Pokémon visibility rules, and highlights the current participant with a stronger card style. 
- Kept the existing desktop/table presentation for TournamentView and added horizontal-scroll affordances and a sticky first-column for the rank column when the table is visible at larger breakpoints. 
- Implemented a matching mobile card layout for final standings in `frontend/src/components/AdminDashboard.tsx` with the same prioritized fields and a desktop table fallback that includes scroll affordances and a sticky first column. 
- Extracted small helpers for Pokémon rendering (`renderPokemonVisibility` / `renderStandingPokemon`) and added a short localized affordance string `commonScrollToSeeMore` in `frontend/src/i18n.tsx`. 
- Updated tests to assert the new scroll affordance copy in `frontend/src/components/TournamentView.test.tsx` and `frontend/src/components/AdminDashboard.test.tsx`.

### Testing
- Ran frontend lint successfully with `cd frontend && npm run lint`. 
- Built types and checked types with `cd frontend && npx tsc -b` which succeeded. 
- Ran the frontend test suite with `cd frontend && npm test` and all tests passed (9 test files, 35 tests). 
- Attempted the repo pre-commit checks with `uv run --project backend pre-commit run --all-files`, but that step failed in this environment because pre-commit could not fetch hook repos from GitHub (`CONNECT tunnel failed, response 403`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baa91634c0832bbe0a95eec1506647)