### PR TITLE
Centralize match reporting checks, add tournament completion service, introduce websocket hook, and adjust migrations/tests

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -14,9 +14,9 @@ from backend.app.core.database import Base
 from backend.app.core.config import settings
 
 # Import models to ensure they are registered with Base.metadata
-from backend.app.api.tournaments.models import Tournament
-from backend.app.api.participants.models import Participant
-from backend.app.api.matches.models import Match
+from backend.app.api.tournaments import models as tournament_models  # noqa: F401
+from backend.app.api.participants import models as participant_models  # noqa: F401
+from backend.app.api.matches import models as match_models  # noqa: F401
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/alembic/versions/34aeb7b524ce_add_pokemon_fields_to_participants.py
+++ b/alembic/versions/34aeb7b524ce_add_pokemon_fields_to_participants.py
@@ -5,6 +5,7 @@ Revises: 22fc4735b24d
 Create Date: 2026-03-07 12:56:14.162733
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -12,8 +13,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = '34aeb7b524ce'
-down_revision: Union[str, Sequence[str], None] = '22fc4735b24d'
+revision: str = "34aeb7b524ce"
+down_revision: Union[str, Sequence[str], None] = "22fc4735b24d"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/b7d1a2c9f44e_add_drop_tracking_to_participants.py
+++ b/alembic/versions/b7d1a2c9f44e_add_drop_tracking_to_participants.py
@@ -5,6 +5,7 @@ Revises: 34aeb7b524ce
 Create Date: 2026-04-19 00:00:00.000000
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -12,8 +13,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = 'b7d1a2c9f44e'
-down_revision: Union[str, Sequence[str], None] = '34aeb7b524ce'
+revision: str = "b7d1a2c9f44e"
+down_revision: Union[str, Sequence[str], None] = "34aeb7b524ce"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -24,7 +25,9 @@ def upgrade() -> None:
         "participants",
         sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
     )
-    op.add_column("participants", sa.Column("dropped_round", sa.Integer(), nullable=True))
+    op.add_column(
+        "participants", sa.Column("dropped_round", sa.Integer(), nullable=True)
+    )
 
 
 def downgrade() -> None:

--- a/backend/app/api/matches/router.py
+++ b/backend/app/api/matches/router.py
@@ -36,7 +36,9 @@ async def report_match_v2(
     if not db_match:
         if not get_tournament_by_code(db, code):
             raise HTTPException(status_code=404, detail="Tournament not found")
-        raise HTTPException(status_code=404, detail="Match not found in this tournament")
+        raise HTTPException(
+            status_code=404, detail="Match not found in this tournament"
+        )
     return db_match
 
 

--- a/backend/app/api/matches/router.py
+++ b/backend/app/api/matches/router.py
@@ -32,38 +32,11 @@ def get_matches(code: str, db: Session = Depends(get_db)):
 async def report_match_v2(
     code: str, match_id: int, update: schemas.MatchUpdate, db: Session = Depends(get_db)
 ):
-    # Check if tournament exists
-    db_tournament = get_tournament_by_code(db, code)
-    if not db_tournament:
-        raise HTTPException(status_code=404, detail="Tournament not found")
-
-    if db_tournament.status == "COMPLETED":
-        raise HTTPException(status_code=400, detail="Tournament is already completed")
-
-    # Check if match exists and belongs to this tournament
-    from .models import Match
-
-    db_match = (
-        db.query(Match)
-        .filter(Match.id == match_id, Match.tournament_id == db_tournament.id)
-        .first()
-    )
+    db_match = await services.report_match_in_tournament(db, code, match_id, update)
     if not db_match:
-        raise HTTPException(
-            status_code=404, detail="Match not found in this tournament"
-        )
-
-    # Permission check
-    if not update.is_admin:
-        if update.reported_by_id is None or update.reported_by_id not in [
-            db_match.player1_id,
-            db_match.player2_id,
-        ]:
-            raise HTTPException(
-                status_code=403, detail="Not authorized to report this match"
-            )
-
-    db_match = await services.report_match(db, match_id, update)
+        if not get_tournament_by_code(db, code):
+            raise HTTPException(status_code=404, detail="Tournament not found")
+        raise HTTPException(status_code=404, detail="Match not found in this tournament")
     return db_match
 
 
@@ -71,29 +44,7 @@ async def report_match_v2(
 async def report_match(
     match_id: int, update: schemas.MatchUpdate, db: Session = Depends(get_db)
 ):
-    # Check if match exists
-    from .models import Match
-    from backend.app.api.tournaments.models import Tournament
-
-    db_match = db.query(Match).filter(Match.id == match_id).first()
+    db_match = await services.report_match_legacy(db, match_id, update)
     if not db_match:
         raise HTTPException(status_code=404, detail="Match not found")
-
-    db_tournament = (
-        db.query(Tournament).filter(Tournament.id == db_match.tournament_id).first()
-    )
-    if db_tournament.status == "COMPLETED":
-        raise HTTPException(status_code=400, detail="Tournament is already completed")
-
-    # Legacy endpoint permission check
-    if not update.is_admin:
-        if update.reported_by_id is None or update.reported_by_id not in [
-            db_match.player1_id,
-            db_match.player2_id,
-        ]:
-            raise HTTPException(
-                status_code=403, detail="Not authorized to report this match"
-            )
-
-    db_match = await services.report_match(db, match_id, update)
     return db_match

--- a/backend/app/api/matches/services.py
+++ b/backend/app/api/matches/services.py
@@ -85,6 +85,36 @@ async def report_match(
     return db_match
 
 
+async def report_match_in_tournament(
+    db: Session, code: str, match_id: int, update: schemas.MatchUpdate
+) -> models.Match:
+    tournament_repo = SqlAlchemyTournamentRepository(db)
+    match_repo = SqlAlchemyMatchRepository(db)
+    tournament = tournament_repo.get_by_code(code)
+    if not tournament:
+        return None
+
+    match = match_repo.get_by_id(match_id)
+    if not match:
+        return None
+
+    use_cases.assert_match_belongs_to_tournament(match=match, tournament=tournament)
+    use_cases.assert_report_permission(match=match, update=update)
+    return await report_match(db=db, match_id=match_id, update=update)
+
+
+async def report_match_legacy(
+    db: Session, match_id: int, update: schemas.MatchUpdate
+) -> models.Match:
+    match_repo = SqlAlchemyMatchRepository(db)
+    match = match_repo.get_by_id(match_id)
+    if not match:
+        return None
+
+    use_cases.assert_report_permission(match=match, update=update)
+    return await report_match(db=db, match_id=match_id, update=update)
+
+
 def get_tournament_matches(db: Session, tournament_id: int) -> List[models.Match]:
     match_repo = SqlAlchemyMatchRepository(db)
     return match_repo.get_by_tournament(tournament_id)

--- a/backend/app/api/matches/use_cases.py
+++ b/backend/app/api/matches/use_cases.py
@@ -139,3 +139,23 @@ def report_match(
         tournaments.save(tournament)
 
     return match
+
+
+def assert_match_belongs_to_tournament(match: Match, tournament: Tournament) -> None:
+    if match.tournament_id != tournament.id:
+        raise HTTPException(
+            status_code=404, detail="Match not found in this tournament"
+        )
+
+
+def assert_report_permission(match: Match, update: MatchUpdate) -> None:
+    if update.is_admin:
+        return
+
+    if update.reported_by_id is None or update.reported_by_id not in [
+        match.player1_id,
+        match.player2_id,
+    ]:
+        raise HTTPException(
+            status_code=403, detail="Not authorized to report this match"
+        )

--- a/backend/app/api/tournaments/router.py
+++ b/backend/app/api/tournaments/router.py
@@ -3,8 +3,6 @@ from sqlalchemy.orm import Session
 from typing import List
 from backend.app.core.database import get_db
 from . import schemas, services, standings
-from backend.app.api.matches.schemas import MatchResponse
-from backend.app.api.matches import models
 from backend.app.api.participants.schemas import ParticipantResponse
 
 router = APIRouter(prefix="/tournaments", tags=["tournaments"])
@@ -25,28 +23,6 @@ def get_tournament(code: str, db: Session = Depends(get_db)):
     return db_tournament
 
 
-# The join endpoint will go to participants router,
-# but for now, I'll keep the ones that are explicitly under /tournaments in main.py
-# or move them here if they are mostly tournament-focused.
-
-# The plan says "Move tournament endpoints to backend/app/api/tournaments/router.py".
-# I'll move everything that starts with /tournaments for now,
-# and then refactor them into sub-routers in Phase 2.
-
-
-@router.get("/{code}/matches", response_model=List[MatchResponse])
-def get_matches(code: str, db: Session = Depends(get_db)):
-    db_tournament = services.get_tournament_by_code(db, code)
-    if not db_tournament:
-        raise HTTPException(status_code=404, detail="Tournament not found")
-
-    return (
-        db.query(models.Match)
-        .filter(models.Match.tournament_id == db_tournament.id)
-        .all()
-    )
-
-
 @router.get("/{code}/standings", response_model=List[ParticipantResponse])
 def get_standings(code: str, db: Session = Depends(get_db)):
     db_tournament = services.get_tournament_by_code(db, code)
@@ -58,21 +34,7 @@ def get_standings(code: str, db: Session = Depends(get_db)):
 
 @router.post("/{code}/complete", response_model=schemas.TournamentResponse)
 async def complete_tournament(code: str, db: Session = Depends(get_db)):
-    from backend.app.core.manager import manager
-
-    db_tournament = services.get_tournament_by_code(db, code)
+    db_tournament = await services.complete_tournament(db, code)
     if not db_tournament:
         raise HTTPException(status_code=404, detail="Tournament not found")
-
-    db_tournament.status = "COMPLETED"
-    db.commit()
-    db.refresh(db_tournament)
-
-    await manager.broadcast(
-        code,
-        {
-            "event": "tournament_completed",
-            "tournament_status": db_tournament.status,
-        },
-    )
     return db_tournament

--- a/backend/app/api/tournaments/services.py
+++ b/backend/app/api/tournaments/services.py
@@ -1,6 +1,7 @@
 from sqlalchemy.orm import Session
 
 from backend.app.adapters.sqlalchemy_repositories import SqlAlchemyTournamentRepository
+from backend.app.core.manager import manager
 
 from . import schemas, use_cases
 
@@ -22,3 +23,22 @@ def create_tournament(db: Session, tournament: schemas.TournamentCreate):
 def get_tournament_by_code(db: Session, code: str):
     tournaments = SqlAlchemyTournamentRepository(db)
     return tournaments.get_by_code(code)
+
+
+async def complete_tournament(db: Session, code: str):
+    tournaments = SqlAlchemyTournamentRepository(db)
+    tournament = tournaments.get_by_code(code)
+    if not tournament:
+        return None
+
+    completed = use_cases.complete_tournament(
+        tournaments=tournaments, tournament=tournament
+    )
+    await manager.broadcast(
+        code,
+        {
+            "event": "tournament_completed",
+            "tournament_status": completed.status,
+        },
+    )
+    return completed

--- a/backend/app/api/tournaments/use_cases.py
+++ b/backend/app/api/tournaments/use_cases.py
@@ -35,3 +35,12 @@ def _generate_room_code(tournaments: TournamentRepositoryPort, length: int = 6) 
 def assert_tournament_can_accept_changes(tournament: Tournament) -> None:
     if tournament.status == "COMPLETED":
         raise HTTPException(status_code=400, detail="Tournament is already completed")
+
+
+def complete_tournament(
+    tournaments: TournamentRepositoryPort, tournament: Tournament
+) -> Tournament:
+    assert_tournament_can_accept_changes(tournament)
+    tournament.status = "COMPLETED"
+    tournaments.save(tournament)
+    return tournament

--- a/backend/tests/test_player_reporting.py
+++ b/backend/tests/test_player_reporting.py
@@ -214,3 +214,25 @@ def test_legacy_report_requires_admin_or_match_participant(setup_db):
     )
     assert unauth_resp.status_code == 403
     assert "Not authorized" in unauth_resp.json()["detail"]
+
+
+def test_v2_report_rejects_match_from_another_tournament(setup_db):
+    first = client.post("/tournaments", json={"name": "T1", "rounds": 1}).json()
+    second = client.post("/tournaments", json={"name": "T2", "rounds": 1}).json()
+
+    client.post(f"/tournaments/{first['code']}/join", json={"name": "A1"})
+    client.post(f"/tournaments/{first['code']}/join", json={"name": "A2"})
+    client.post(f"/tournaments/{first['code']}/pairings")
+
+    client.post(f"/tournaments/{second['code']}/join", json={"name": "B1"})
+    client.post(f"/tournaments/{second['code']}/join", json={"name": "B2"})
+    client.post(f"/tournaments/{second['code']}/pairings")
+
+    foreign_match = client.get(f"/tournaments/{second['code']}/matches").json()[0]
+    resp = client.post(
+        f"/tournaments/{first['code']}/matches/{foreign_match['id']}/report",
+        json={"player1_score": 2, "player2_score": 0, "is_admin": True},
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Match not found in this tournament"

--- a/frontend/src/components/AdminDashboard.tsx
+++ b/frontend/src/components/AdminDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { config } from '../config';
 import ParticipantList from './ParticipantList';
@@ -7,6 +7,7 @@ import { useLanguage } from '../i18n';
 import PokemonSprite from './PokemonSprite';
 import ReportMatchModal from './ReportMatchModal';
 import { usePokemonList } from '../hooks/usePokemonList';
+import { useTournamentSocket } from '../hooks/useTournamentSocket';
 
 interface Tournament {
   id: number;
@@ -83,16 +84,72 @@ export default function AdminDashboard() {
     }
   }, [tournament]);
 
+  const fetchMatches = useCallback(async () => {
+    if (!tournament) return;
+    try {
+      const response = await fetch(`${config.apiUrl}/tournaments/${tournament.code}/matches`);
+      if (response.ok) {
+        const data = await response.json();
+        setMatches(data);
+      }
+    } catch (err) {
+      console.error('Failed to fetch matches', err);
+    }
+  }, [tournament]);
+
+  const fetchParticipants = useCallback(async () => {
+    if (!tournament) return;
+    try {
+      const response = await fetch(`${config.apiUrl}/tournaments/${tournament.code}/participants`);
+      if (response.ok) {
+        const data = await response.json();
+        setParticipants(data);
+      }
+    } catch (err) {
+      console.error('Failed to fetch participants', err);
+    }
+  }, [tournament]);
+
+  const fetchStandings = useCallback(async () => {
+    if (!tournament) return;
+    try {
+      const response = await fetch(`${config.apiUrl}/tournaments/${tournament.code}/standings`);
+      if (response.ok) {
+        const data = await response.json();
+        setStandings(data);
+      }
+    } catch (err) {
+      console.error('Failed to fetch standings', err);
+    }
+  }, [tournament]);
+
+  const fetchTournament = useCallback(async () => {
+    if (!tournament) return;
+    try {
+      const response = await fetch(`${config.apiUrl}/tournaments/${tournament.code}`);
+      if (response.ok) {
+        const data = await response.json();
+        setTournament(data);
+      }
+    } catch (err) {
+      console.error('Failed to fetch tournament', err);
+    }
+  }, [tournament]);
+
   useEffect(() => {
     if (!tournament) return;
-
     fetchMatches();
     fetchParticipants();
     fetchStandings();
+  }, [fetchMatches, fetchParticipants, fetchStandings, tournament]);
 
-    const ws = new WebSocket(`${config.wsUrl}/ws/${tournament.code}`);
-    ws.onmessage = (event) => {
-      const message = JSON.parse(event.data);
+  useTournamentSocket({
+    code: tournament?.code,
+    onMessage: (payload) => {
+      const message = payload as {
+        event?: string;
+        data?: { name?: string; timestamp?: string };
+      };
 
       if (
         message.event === 'participant_joined'
@@ -109,77 +166,23 @@ export default function AdminDashboard() {
 
       if (message.event === 'participant_joined') {
         const newEvent: ActivityEvent = {
-          id: Math.random().toString(36).substr(2, 9),
+          id: Math.random().toString(36).substring(2, 11),
           type: message.event,
-          message: t('adminJoinedTournament', { name: message.data.name }),
-          timestamp: message.data.timestamp || new Date().toISOString(),
+          message: t('adminJoinedTournament', { name: message.data?.name ?? '' }),
+          timestamp: message.data?.timestamp || new Date().toISOString(),
         };
         setEvents((prev) => [...prev, newEvent]);
       } else if (message.event === 'match_reported') {
         const newEvent: ActivityEvent = {
-          id: Math.random().toString(36).substr(2, 9),
+          id: Math.random().toString(36).substring(2, 11),
           type: message.event,
           message: t('adminMatchReported'),
           timestamp: new Date().toISOString(),
         };
         setEvents((prev) => [...prev, newEvent]);
       }
-    };
-
-    return () => ws.close();
-  }, [tournament, t]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const fetchMatches = async () => {
-    if (!tournament) return;
-    try {
-      const response = await fetch(`${config.apiUrl}/tournaments/${tournament.code}/matches`);
-      if (response.ok) {
-        const data = await response.json();
-        setMatches(data);
-      }
-    } catch (err) {
-      console.error('Failed to fetch matches', err);
-    }
-  };
-
-  const fetchParticipants = async () => {
-    if (!tournament) return;
-    try {
-      const response = await fetch(`${config.apiUrl}/tournaments/${tournament.code}/participants`);
-      if (response.ok) {
-        const data = await response.json();
-        setParticipants(data);
-      }
-    } catch (err) {
-      console.error('Failed to fetch participants', err);
-    }
-  };
-
-  const fetchStandings = async () => {
-    if (!tournament) return;
-    try {
-      const response = await fetch(`${config.apiUrl}/tournaments/${tournament.code}/standings`);
-      if (response.ok) {
-        const data = await response.json();
-        setStandings(data);
-      }
-    } catch (err) {
-      console.error('Failed to fetch standings', err);
-    }
-  };
-
-  const fetchTournament = async () => {
-    if (!tournament) return;
-    try {
-      const response = await fetch(`${config.apiUrl}/tournaments/${tournament.code}`);
-      if (response.ok) {
-        const data = await response.json();
-        setTournament(data);
-      }
-    } catch (err) {
-      console.error('Failed to fetch tournament', err);
-    }
-  };
+    },
+  });
 
   const handleCreateTournament = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/components/TournamentView.tsx
+++ b/frontend/src/components/TournamentView.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { config } from '../config';
 import PokemonSprite from './PokemonSprite';
 import { useLanguage } from '../i18n';
 import ReportMatchModal from './ReportMatchModal';
+import { useTournamentSocket } from '../hooks/useTournamentSocket';
 
 interface Match {
   id: number;
@@ -67,49 +68,7 @@ export default function TournamentView() {
 
     const tournamentCompleted = tournamentStatus === 'COMPLETED';
 
-    useEffect(() => {
-
-    if (!code) return;
-
-    fetchData();
-
-    let ws: WebSocket | null = null;
-    let reconnectTimer: number | null = null;
-
-    const connect = () => {
-      setSocketStatus((prev) => (prev === 'connected' ? prev : 'connecting'));
-      ws = new WebSocket(`${config.wsUrl}/ws/${code}`);
-
-      ws.onopen = () => {
-        setSocketStatus('connected');
-      };
-
-      ws.onmessage = (event) => {
-        const message = JSON.parse(event.data);
-        if (message.event === 'pairings_generated' || message.event === 'match_reported' || message.event === 'participant_joined' || message.event === 'tournament_completed') {
-          fetchData();
-        }
-      };
-
-      ws.onclose = () => {
-        setSocketStatus('reconnecting');
-        reconnectTimer = window.setTimeout(() => connect(), 1500);
-      };
-
-      ws.onerror = () => {
-        setSocketStatus('offline');
-      };
-    };
-
-    connect();
-
-    return () => {
-      if (reconnectTimer) window.clearTimeout(reconnectTimer);
-      ws?.close();
-    };
-  }, [code]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const fetchData = async () => {
+  const fetchData = useCallback(async () => {
     try {
       const [matchesRes, standingsRes, tournamentRes] = await Promise.all([
         fetch(`${config.apiUrl}/tournaments/${code}/matches`),
@@ -144,7 +103,37 @@ export default function TournamentView() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [code, participantId]);
+
+  useEffect(() => {
+    if (!code) return;
+    fetchData();
+  }, [code, fetchData]);
+
+  useTournamentSocket({
+    code,
+    enableReconnect: true,
+    onOpen: () => {
+      setSocketStatus('connected');
+    },
+    onClose: () => {
+      setSocketStatus('reconnecting');
+    },
+    onError: () => {
+      setSocketStatus('offline');
+    },
+    onMessage: (payload) => {
+      const message = payload as { event?: string };
+      if (
+        message.event === 'pairings_generated'
+        || message.event === 'match_reported'
+        || message.event === 'participant_joined'
+        || message.event === 'tournament_completed'
+      ) {
+        fetchData();
+      }
+    },
+  });
 
   const handleReportSubmit = async () => {
     if (!reportingMatch || !selectedPreset) return;

--- a/frontend/src/hooks/useTournamentSocket.test.tsx
+++ b/frontend/src/hooks/useTournamentSocket.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useTournamentSocket } from './useTournamentSocket';
+
+function SocketHarness({ marker }: { marker: string }) {
+  useTournamentSocket({
+    code: 'ABCDEF',
+    onMessage: () => undefined,
+  });
+
+  return <div>{marker}</div>;
+}
+
+describe('useTournamentSocket', () => {
+  beforeEach(() => {
+    const MockWebSocket = vi.fn().mockImplementation(function () {
+      this.onopen = null;
+      this.onmessage = null;
+      this.onerror = null;
+      this.onclose = null;
+      this.close = vi.fn();
+    });
+
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket);
+  });
+
+  it('does not recreate socket on unrelated rerenders', async () => {
+    const { rerender } = render(<SocketHarness marker="first" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('first')).toBeInTheDocument();
+    });
+
+    rerender(<SocketHarness marker="second" />);
+    expect(screen.getByText('second')).toBeInTheDocument();
+    expect(WebSocket).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/useTournamentSocket.ts
+++ b/frontend/src/hooks/useTournamentSocket.ts
@@ -1,0 +1,59 @@
+import { useEffect } from 'react';
+import { config } from '../config';
+
+interface UseTournamentSocketParams {
+  code?: string;
+  onMessage: (payload: unknown) => void;
+  onOpen?: () => void;
+  onClose?: () => void;
+  onError?: () => void;
+  reconnectDelayMs?: number;
+  enableReconnect?: boolean;
+}
+
+export function useTournamentSocket({
+  code,
+  onMessage,
+  onOpen,
+  onClose,
+  onError,
+  reconnectDelayMs = 1500,
+  enableReconnect = false,
+}: UseTournamentSocketParams) {
+  useEffect(() => {
+    if (!code) return undefined;
+
+    let ws: WebSocket | null = null;
+    let reconnectTimer: number | null = null;
+    let isUnmounted = false;
+
+    const connect = () => {
+      ws = new WebSocket(`${config.wsUrl}/ws/${code}`);
+      ws.onopen = () => onOpen?.();
+      ws.onmessage = (event) => onMessage(JSON.parse(event.data));
+      ws.onerror = () => onError?.();
+      ws.onclose = () => {
+        onClose?.();
+        if (enableReconnect && !isUnmounted) {
+          reconnectTimer = window.setTimeout(connect, reconnectDelayMs);
+        }
+      };
+    };
+
+    connect();
+
+    return () => {
+      isUnmounted = true;
+      if (reconnectTimer) window.clearTimeout(reconnectTimer);
+      ws?.close();
+    };
+  }, [
+    code,
+    enableReconnect,
+    onClose,
+    onError,
+    onMessage,
+    onOpen,
+    reconnectDelayMs,
+  ]);
+}

--- a/frontend/src/hooks/useTournamentSocket.ts
+++ b/frontend/src/hooks/useTournamentSocket.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { config } from '../config';
 
 interface UseTournamentSocketParams {
@@ -20,6 +20,18 @@ export function useTournamentSocket({
   reconnectDelayMs = 1500,
   enableReconnect = false,
 }: UseTournamentSocketParams) {
+  const onMessageRef = useRef(onMessage);
+  const onOpenRef = useRef(onOpen);
+  const onCloseRef = useRef(onClose);
+  const onErrorRef = useRef(onError);
+
+  useEffect(() => {
+    onMessageRef.current = onMessage;
+    onOpenRef.current = onOpen;
+    onCloseRef.current = onClose;
+    onErrorRef.current = onError;
+  }, [onClose, onError, onMessage, onOpen]);
+
   useEffect(() => {
     if (!code) return undefined;
 
@@ -29,11 +41,11 @@ export function useTournamentSocket({
 
     const connect = () => {
       ws = new WebSocket(`${config.wsUrl}/ws/${code}`);
-      ws.onopen = () => onOpen?.();
-      ws.onmessage = (event) => onMessage(JSON.parse(event.data));
-      ws.onerror = () => onError?.();
+      ws.onopen = () => onOpenRef.current?.();
+      ws.onmessage = (event) => onMessageRef.current(JSON.parse(event.data));
+      ws.onerror = () => onErrorRef.current?.();
       ws.onclose = () => {
-        onClose?.();
+        onCloseRef.current?.();
         if (enableReconnect && !isUnmounted) {
           reconnectTimer = window.setTimeout(connect, reconnectDelayMs);
         }
@@ -47,13 +59,5 @@ export function useTournamentSocket({
       if (reconnectTimer) window.clearTimeout(reconnectTimer);
       ws?.close();
     };
-  }, [
-    code,
-    enableReconnect,
-    onClose,
-    onError,
-    onMessage,
-    onOpen,
-    reconnectDelayMs,
-  ]);
+  }, [code, enableReconnect, reconnectDelayMs]);
 }


### PR DESCRIPTION
### Motivation

- Centralize and reuse match permission and ownership checks to avoid duplicated logic and to ensure v2 endpoints validate tournament membership before accepting reports.
- Move tournament completion logic into an async service so the operation can broadcast updates to connected clients via the manager.
- Replace ad-hoc WebSocket management in components with a reusable `useTournamentSocket` hook and stabilize data fetching with `useCallback` to avoid duplicate logic and reconnection boilerplate.
- Normalize minor Alembic file formatting and module imports so model modules are imported for `Base.metadata` discovery.

### Description

- Added service-level helpers `report_match_in_tournament` and `report_match_legacy` in `backend/app/api/matches/services.py` and moved ownership/permission checks into `backend/app/api/matches/use_cases.py` as `assert_match_belongs_to_tournament` and `assert_report_permission`, and updated the matches router to delegate to these services (`report_match_v2` and legacy `report_match`).
- Introduced `complete_tournament` use-case and async service (`backend/app/api/tournaments/use_cases.py` and `backend/app/api/tournaments/services.py`) to mark tournaments completed and broadcast `tournament_completed` via the `manager`, and updated the tournaments router to call the service.
- Frontend refactor: created `useTournamentSocket` hook (`frontend/src/hooks/useTournamentSocket.ts`) and refactored `AdminDashboard.tsx` and `TournamentView.tsx` to use `useTournamentSocket`, replace inline WebSocket code, and memoize fetch functions with `useCallback` for stable dependencies.
- Tests: added `test_v2_report_rejects_match_from_another_tournament` to `backend/tests/test_player_reporting.py` to assert v2 reporting rejects matches from other tournaments.
- Minor Alembic changes: normalized quoting/formatting in migration headers and switched model imports in `alembic/env.py` to import modules (ensuring models register with `Base.metadata`).

### Testing

- Ran the new unit test: `pytest backend/tests/test_player_reporting.py::test_v2_report_rejects_match_from_another_tournament` and it passed.
- Ran backend test suite with `pytest -q` for affected areas and the tests covering match reporting and tournament completion passed.
- Verified frontend type/build by running the app build commands in development (no runtime errors observed during manual smoke testing of WebSocket flows).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58b819ce4832b92d9dfdbb1325205)