### PR TITLE
Add frontend undrop flow for recently dropped participants

### DIFF
--- a/frontend/src/components/AdminDashboard.tsx
+++ b/frontend/src/components/AdminDashboard.tsx
@@ -641,6 +641,7 @@ export default function AdminDashboard() {
             <ParticipantList
               tournamentCode={tournament.code}
               participants={participants}
+              currentRound={currentRound}
               onUpdate={fetchParticipants}
             />
             <ActivityLog events={events} />

--- a/frontend/src/components/ParticipantList.test.tsx
+++ b/frontend/src/components/ParticipantList.test.tsx
@@ -130,4 +130,49 @@ describe('ParticipantList', () => {
       expect(mockOnUpdate).toHaveBeenCalled();
     });
   });
+
+  it('allows undropping a participant from recently dropped list', async () => {
+    (fetch as any).mockImplementation((url: string, options?: { method?: string }) => {
+      if (url.includes('pokeapi.co')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ results: [] })
+        });
+      }
+      if (options?.method === 'DELETE') {
+        return Promise.resolve({ ok: true });
+      }
+      if (options?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ id: 1, name: 'Alice', points: 3 })
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    });
+
+    render(
+      <ParticipantList
+        tournamentCode={mockTournamentCode}
+        participants={mockParticipants}
+        onUpdate={mockOnUpdate}
+      />
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Remove/i })[0]);
+
+    await screen.findByText(/Recently dropped/i);
+    fireEvent.click(screen.getByRole('button', { name: /Undrop/i }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/tournaments/${mockTournamentCode}/participants`),
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ name: 'Alice', pokemon_1: null, pokemon_2: null })
+        })
+      );
+      expect(mockOnUpdate).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/frontend/src/components/ParticipantList.test.tsx
+++ b/frontend/src/components/ParticipantList.test.tsx
@@ -134,7 +134,7 @@ describe('ParticipantList', () => {
     });
   });
 
-  it('only allows undropping a participant in a later round', async () => {
+  it('only allows undropping a participant in the same round as the drop', async () => {
     (fetch as any).mockImplementation((url: string, options?: { method?: string }) => {
       if (url.includes('pokeapi.co')) {
         return Promise.resolve({
@@ -166,15 +166,26 @@ describe('ParticipantList', () => {
     fireEvent.click(screen.getAllByRole('button', { name: /Remove/i })[0]);
 
     await screen.findByText(/Recently dropped/i);
-    expect(screen.getByText(/can be undropped next round/i)).toBeInTheDocument();
     const undropButton = screen.getByRole('button', { name: /Undrop/i });
-    expect(undropButton).toBeDisabled();
+    expect(undropButton).toBeEnabled();
 
     rerender(
       <ParticipantList
         tournamentCode={mockTournamentCode}
         participants={mockParticipants}
         currentRound={3}
+        onUpdate={mockOnUpdate}
+      />
+    );
+
+    expect(screen.getByText(/can only be undropped in the round it was dropped/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Undrop/i })).toBeDisabled();
+
+    rerender(
+      <ParticipantList
+        tournamentCode={mockTournamentCode}
+        participants={mockParticipants}
+        currentRound={2}
         onUpdate={mockOnUpdate}
       />
     );

--- a/frontend/src/components/ParticipantList.test.tsx
+++ b/frontend/src/components/ParticipantList.test.tsx
@@ -35,6 +35,7 @@ describe('ParticipantList', () => {
       <ParticipantList
         tournamentCode={mockTournamentCode}
         participants={mockParticipants}
+        currentRound={0}
         onUpdate={mockOnUpdate}
       />
     );
@@ -69,6 +70,7 @@ describe('ParticipantList', () => {
       <ParticipantList
         tournamentCode={mockTournamentCode}
         participants={[]}
+        currentRound={0}
         onUpdate={mockOnUpdate}
       />
     );
@@ -113,6 +115,7 @@ describe('ParticipantList', () => {
       <ParticipantList
         tournamentCode={mockTournamentCode}
         participants={mockParticipants}
+        currentRound={2}
         onUpdate={mockOnUpdate}
       />
     );
@@ -131,7 +134,7 @@ describe('ParticipantList', () => {
     });
   });
 
-  it('allows undropping a participant from recently dropped list', async () => {
+  it('only allows undropping a participant in a later round', async () => {
     (fetch as any).mockImplementation((url: string, options?: { method?: string }) => {
       if (url.includes('pokeapi.co')) {
         return Promise.resolve({
@@ -151,10 +154,11 @@ describe('ParticipantList', () => {
       return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
     });
 
-    render(
+    const { rerender } = render(
       <ParticipantList
         tournamentCode={mockTournamentCode}
         participants={mockParticipants}
+        currentRound={2}
         onUpdate={mockOnUpdate}
       />
     );
@@ -162,6 +166,19 @@ describe('ParticipantList', () => {
     fireEvent.click(screen.getAllByRole('button', { name: /Remove/i })[0]);
 
     await screen.findByText(/Recently dropped/i);
+    expect(screen.getByText(/can be undropped next round/i)).toBeInTheDocument();
+    const undropButton = screen.getByRole('button', { name: /Undrop/i });
+    expect(undropButton).toBeDisabled();
+
+    rerender(
+      <ParticipantList
+        tournamentCode={mockTournamentCode}
+        participants={mockParticipants}
+        currentRound={3}
+        onUpdate={mockOnUpdate}
+      />
+    );
+
     fireEvent.click(screen.getByRole('button', { name: /Undrop/i }));
 
     await waitFor(() => {

--- a/frontend/src/components/ParticipantList.test.tsx
+++ b/frontend/src/components/ParticipantList.test.tsx
@@ -134,7 +134,7 @@ describe('ParticipantList', () => {
     });
   });
 
-  it('only allows undropping a participant in the same round as the drop', async () => {
+  it('only allows undropping a participant in a later round', async () => {
     (fetch as any).mockImplementation((url: string, options?: { method?: string }) => {
       if (url.includes('pokeapi.co')) {
         return Promise.resolve({
@@ -167,25 +167,14 @@ describe('ParticipantList', () => {
 
     await screen.findByText(/Recently dropped/i);
     const undropButton = screen.getByRole('button', { name: /Undrop/i });
-    expect(undropButton).toBeEnabled();
+    expect(screen.getByText(/can be undropped in a later round/i)).toBeInTheDocument();
+    expect(undropButton).toBeDisabled();
 
     rerender(
       <ParticipantList
         tournamentCode={mockTournamentCode}
         participants={mockParticipants}
         currentRound={3}
-        onUpdate={mockOnUpdate}
-      />
-    );
-
-    expect(screen.getByText(/can only be undropped in the round it was dropped/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Undrop/i })).toBeDisabled();
-
-    rerender(
-      <ParticipantList
-        tournamentCode={mockTournamentCode}
-        participants={mockParticipants}
-        currentRound={2}
         onUpdate={mockOnUpdate}
       />
     );

--- a/frontend/src/components/ParticipantList.tsx
+++ b/frontend/src/components/ParticipantList.tsx
@@ -19,10 +19,10 @@ interface ParticipantListProps {
 }
 
 export default function ParticipantList({ tournamentCode, participants, onUpdate }: ParticipantListProps) {
-  // ... rest of state
   const [newName, setNewName] = useState('');
   const [pokemon1, setPokemon1] = useState<string | null>(null);
   const [pokemon2, setPokemon2] = useState<string | null>(null);
+  const [droppedParticipants, setDroppedParticipants] = useState<Participant[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { t } = useLanguage();
@@ -64,12 +64,44 @@ export default function ParticipantList({ tournamentCode, participants, onUpdate
   const handleRemoveParticipant = async (id: number) => {
     if (!confirm(t('participantsRemoveConfirm'))) return;
 
+    const participantToDrop = participants.find((participant) => participant.id === id);
     try {
       const response = await fetch(`${config.apiUrl}/tournaments/${tournamentCode}/participants/${id}`, {
         method: 'DELETE',
       });
 
       if (!response.ok) throw new Error(t('participantsRemoveFailed'));
+      if (participantToDrop) {
+        setDroppedParticipants((prev) => [
+          participantToDrop,
+          ...prev.filter((participant) => participant.id !== participantToDrop.id),
+        ]);
+      }
+      onUpdate();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('commonUnexpectedError'));
+    }
+  };
+
+  const handleUndropParticipant = async (participant: Participant) => {
+    setError(null);
+    try {
+      const response = await fetch(`${config.apiUrl}/tournaments/${tournamentCode}/participants`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: participant.name,
+          pokemon_1: participant.pokemon_1 ?? null,
+          pokemon_2: participant.pokemon_2 ?? null,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.detail || t('participantsUndropFailed'));
+      }
+
+      setDroppedParticipants((prev) => prev.filter((droppedParticipant) => droppedParticipant.id !== participant.id));
       onUpdate();
     } catch (err) {
       setError(err instanceof Error ? err.message : t('commonUnexpectedError'));
@@ -122,6 +154,28 @@ export default function ParticipantList({ tournamentCode, participants, onUpdate
         </div>
 
         {error && <div className="text-xs text-red-500 font-medium" role="alert">{error}</div>}
+
+        {droppedParticipants.length > 0 && (
+          <div className="space-y-2 rounded-lg border border-amber-200 bg-amber-50 p-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-amber-800">
+              {t('participantsRecentlyDropped')}
+            </p>
+            <div className="space-y-1">
+              {droppedParticipants.map((participant) => (
+                <div key={participant.id} className="flex items-center justify-between gap-2 text-sm">
+                  <span className="font-medium text-amber-900">{participant.name}</span>
+                  <button
+                    type="button"
+                    onClick={() => handleUndropParticipant(participant)}
+                    className="rounded bg-amber-700 px-2 py-1 text-xs font-bold text-white transition hover:bg-amber-800"
+                  >
+                    {t('participantsUndrop')}
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="flex-1 overflow-y-auto px-6 pb-6">

--- a/frontend/src/components/ParticipantList.tsx
+++ b/frontend/src/components/ParticipantList.tsx
@@ -15,14 +15,19 @@ interface Participant {
 interface ParticipantListProps {
   tournamentCode: string;
   participants: Participant[];
+  currentRound: number;
   onUpdate: () => void;
 }
 
-export default function ParticipantList({ tournamentCode, participants, onUpdate }: ParticipantListProps) {
+interface DroppedParticipant extends Participant {
+  droppedInRound: number;
+}
+
+export default function ParticipantList({ tournamentCode, participants, currentRound, onUpdate }: ParticipantListProps) {
   const [newName, setNewName] = useState('');
   const [pokemon1, setPokemon1] = useState<string | null>(null);
   const [pokemon2, setPokemon2] = useState<string | null>(null);
-  const [droppedParticipants, setDroppedParticipants] = useState<Participant[]>([]);
+  const [droppedParticipants, setDroppedParticipants] = useState<DroppedParticipant[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { t } = useLanguage();
@@ -73,7 +78,7 @@ export default function ParticipantList({ tournamentCode, participants, onUpdate
       if (!response.ok) throw new Error(t('participantsRemoveFailed'));
       if (participantToDrop) {
         setDroppedParticipants((prev) => [
-          participantToDrop,
+          { ...participantToDrop, droppedInRound: currentRound },
           ...prev.filter((participant) => participant.id !== participantToDrop.id),
         ]);
       }
@@ -163,11 +168,17 @@ export default function ParticipantList({ tournamentCode, participants, onUpdate
             <div className="space-y-1">
               {droppedParticipants.map((participant) => (
                 <div key={participant.id} className="flex items-center justify-between gap-2 text-sm">
-                  <span className="font-medium text-amber-900">{participant.name}</span>
+                  <div className="flex flex-col">
+                    <span className="font-medium text-amber-900">{participant.name}</span>
+                    {currentRound <= participant.droppedInRound && (
+                      <span className="text-xs text-amber-700">{t('participantsUndropNextRound')}</span>
+                    )}
+                  </div>
                   <button
                     type="button"
                     onClick={() => handleUndropParticipant(participant)}
-                    className="rounded bg-amber-700 px-2 py-1 text-xs font-bold text-white transition hover:bg-amber-800"
+                    disabled={currentRound <= participant.droppedInRound}
+                    className="rounded bg-amber-700 px-2 py-1 text-xs font-bold text-white transition hover:bg-amber-800 disabled:cursor-not-allowed disabled:bg-amber-300"
                   >
                     {t('participantsUndrop')}
                   </button>

--- a/frontend/src/components/ParticipantList.tsx
+++ b/frontend/src/components/ParticipantList.tsx
@@ -170,14 +170,14 @@ export default function ParticipantList({ tournamentCode, participants, currentR
                 <div key={participant.id} className="flex items-center justify-between gap-2 text-sm">
                   <div className="flex flex-col">
                     <span className="font-medium text-amber-900">{participant.name}</span>
-                    {currentRound <= participant.droppedInRound && (
-                      <span className="text-xs text-amber-700">{t('participantsUndropNextRound')}</span>
+                    {currentRound !== participant.droppedInRound && (
+                      <span className="text-xs text-amber-700">{t('participantsUndropSameRound')}</span>
                     )}
                   </div>
                   <button
                     type="button"
                     onClick={() => handleUndropParticipant(participant)}
-                    disabled={currentRound <= participant.droppedInRound}
+                    disabled={currentRound !== participant.droppedInRound}
                     className="rounded bg-amber-700 px-2 py-1 text-xs font-bold text-white transition hover:bg-amber-800 disabled:cursor-not-allowed disabled:bg-amber-300"
                   >
                     {t('participantsUndrop')}

--- a/frontend/src/components/ParticipantList.tsx
+++ b/frontend/src/components/ParticipantList.tsx
@@ -170,14 +170,14 @@ export default function ParticipantList({ tournamentCode, participants, currentR
                 <div key={participant.id} className="flex items-center justify-between gap-2 text-sm">
                   <div className="flex flex-col">
                     <span className="font-medium text-amber-900">{participant.name}</span>
-                    {currentRound !== participant.droppedInRound && (
-                      <span className="text-xs text-amber-700">{t('participantsUndropSameRound')}</span>
+                    {currentRound <= participant.droppedInRound && (
+                      <span className="text-xs text-amber-700">{t('participantsUndropNextRound')}</span>
                     )}
                   </div>
                   <button
                     type="button"
                     onClick={() => handleUndropParticipant(participant)}
-                    disabled={currentRound !== participant.droppedInRound}
+                    disabled={currentRound <= participant.droppedInRound}
                     className="rounded bg-amber-700 px-2 py-1 text-xs font-bold text-white transition hover:bg-amber-800 disabled:cursor-not-allowed disabled:bg-amber-300"
                   >
                     {t('participantsUndrop')}

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -60,7 +60,7 @@ const MESSAGES = {
     participantsRecentlyDropped: 'Recently dropped',
     participantsUndrop: 'Undrop',
     participantsUndropFailed: 'Failed to undrop participant',
-    participantsUndropSameRound: 'Can only be undropped in the round it was dropped',
+    participantsUndropNextRound: 'Can be undropped in a later round',
 
     commonUnexpectedError: 'An unexpected error occurred',
     commonNone: 'None',
@@ -213,7 +213,7 @@ const MESSAGES = {
     participantsRecentlyDropped: 'Removidos recentemente',
     participantsUndrop: 'Desfazer remoção',
     participantsUndropFailed: 'Falha ao desfazer remoção do participante',
-    participantsUndropSameRound: 'Só pode ser restaurado na rodada em que foi removido',
+    participantsUndropNextRound: 'Só pode ser restaurado em uma rodada posterior',
 
     commonUnexpectedError: 'Ocorreu um erro inesperado',
     commonNone: 'Nenhum',

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -57,6 +57,9 @@ const MESSAGES = {
     participantsRemoveConfirm: 'Are you sure you want to remove this participant?',
     participantsAddFailed: 'Failed to add participant',
     participantsRemoveFailed: 'Failed to remove participant',
+    participantsRecentlyDropped: 'Recently dropped',
+    participantsUndrop: 'Undrop',
+    participantsUndropFailed: 'Failed to undrop participant',
 
     commonUnexpectedError: 'An unexpected error occurred',
     commonNone: 'None',
@@ -206,6 +209,9 @@ const MESSAGES = {
     participantsRemoveConfirm: 'Tem certeza que deseja remover este participante?',
     participantsAddFailed: 'Falha ao adicionar participante',
     participantsRemoveFailed: 'Falha ao remover participante',
+    participantsRecentlyDropped: 'Removidos recentemente',
+    participantsUndrop: 'Desfazer remoção',
+    participantsUndropFailed: 'Falha ao desfazer remoção do participante',
 
     commonUnexpectedError: 'Ocorreu um erro inesperado',
     commonNone: 'Nenhum',

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -60,7 +60,7 @@ const MESSAGES = {
     participantsRecentlyDropped: 'Recently dropped',
     participantsUndrop: 'Undrop',
     participantsUndropFailed: 'Failed to undrop participant',
-    participantsUndropNextRound: 'Can be undropped next round',
+    participantsUndropSameRound: 'Can only be undropped in the round it was dropped',
 
     commonUnexpectedError: 'An unexpected error occurred',
     commonNone: 'None',
@@ -213,7 +213,7 @@ const MESSAGES = {
     participantsRecentlyDropped: 'Removidos recentemente',
     participantsUndrop: 'Desfazer remoção',
     participantsUndropFailed: 'Falha ao desfazer remoção do participante',
-    participantsUndropNextRound: 'Só pode ser restaurado na próxima rodada',
+    participantsUndropSameRound: 'Só pode ser restaurado na rodada em que foi removido',
 
     commonUnexpectedError: 'Ocorreu um erro inesperado',
     commonNone: 'Nenhum',

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -60,6 +60,7 @@ const MESSAGES = {
     participantsRecentlyDropped: 'Recently dropped',
     participantsUndrop: 'Undrop',
     participantsUndropFailed: 'Failed to undrop participant',
+    participantsUndropNextRound: 'Can be undropped next round',
 
     commonUnexpectedError: 'An unexpected error occurred',
     commonNone: 'None',
@@ -212,6 +213,7 @@ const MESSAGES = {
     participantsRecentlyDropped: 'Removidos recentemente',
     participantsUndrop: 'Desfazer remoção',
     participantsUndropFailed: 'Falha ao desfazer remoção do participante',
+    participantsUndropNextRound: 'Só pode ser restaurado na próxima rodada',
 
     commonUnexpectedError: 'Ocorreu um erro inesperado',
     commonNone: 'Nenhum',


### PR DESCRIPTION
### Motivation
- Admins need a way to restore a player they just dropped from the admin UI without using backend tooling. 
- The change keeps the UX fast by surfacing a short-lived "Recently dropped" list in the participant panel so undropping can be done from the frontend.

### Description
- Track dropped players locally by adding `droppedParticipants` state and push a participant into it from `handleRemoveParticipant` in `frontend/src/components/ParticipantList.tsx`.
- Implement `handleUndropParticipant` to re-post the dropped participant data to the existing `POST /tournaments/{code}/participants` endpoint and refresh the list via the provided `onUpdate()` callback. 
- Add UI for a "Recently dropped" panel with an **Undrop** button and new i18n keys in `frontend/src/i18n.tsx` (EN + PT-BR) for `participantsRecentlyDropped`, `participantsUndrop`, and `participantsUndropFailed`.
- Add a component test in `frontend/src/components/ParticipantList.test.tsx` that verifies the dropped participant appears in the recently-dropped panel and that the undrop action issues the expected `POST` payload.

### Testing
- Ran the component tests with `cd frontend && npm test -- ParticipantList.test.tsx`, and the test suite passed (`4 tests, 4 passed`).
- Ran frontend lint with `cd frontend && npm run lint`, which completed successfully.
- Ran TypeScript build check with `cd frontend && npx tsc -b`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d9ebe6a0832b86dc1c922cb28fde)