### PR TITLE
Allow admin undrop of players only in the round they were dropped

### DIFF
--- a/backend/app/adapters/sqlalchemy_repositories.py
+++ b/backend/app/adapters/sqlalchemy_repositories.py
@@ -39,15 +39,13 @@ class SqlAlchemyParticipantRepository:
     def __init__(self, db: Session):
         self.db = db
 
-    def get_by_tournament(self, tournament_id: int) -> List[Participant]:
-        return (
-            self.db.query(Participant)
-            .filter(
-                Participant.tournament_id == tournament_id,
-                Participant.is_active.is_(True),
-            )
-            .all()
-        )
+    def get_by_tournament(
+        self, tournament_id: int, include_inactive: bool = False
+    ) -> List[Participant]:
+        query = self.db.query(Participant).filter(Participant.tournament_id == tournament_id)
+        if not include_inactive:
+            query = query.filter(Participant.is_active.is_(True))
+        return query.all()
 
     def get_by_id(self, participant_id: int) -> Optional[Participant]:
         return (

--- a/backend/app/adapters/sqlalchemy_repositories.py
+++ b/backend/app/adapters/sqlalchemy_repositories.py
@@ -42,7 +42,9 @@ class SqlAlchemyParticipantRepository:
     def get_by_tournament(
         self, tournament_id: int, include_inactive: bool = False
     ) -> List[Participant]:
-        query = self.db.query(Participant).filter(Participant.tournament_id == tournament_id)
+        query = self.db.query(Participant).filter(
+            Participant.tournament_id == tournament_id
+        )
         if not include_inactive:
             query = query.filter(Participant.is_active.is_(True))
         return query.all()

--- a/backend/app/api/participants/router.py
+++ b/backend/app/api/participants/router.py
@@ -40,12 +40,18 @@ async def admin_add_participant(
 
 
 @router.get("/{code}/participants", response_model=List[schemas.ParticipantResponse])
-async def list_participants(code: str, db: Session = Depends(get_db)):
+async def list_participants(
+    code: str,
+    include_dropped: bool = False,
+    db: Session = Depends(get_db),
+):
     db_tournament = get_tournament_by_code(db, code)
     if not db_tournament:
         raise HTTPException(status_code=404, detail="Tournament not found")
 
-    return services.get_participants(db, db_tournament.id)
+    return services.get_participants(
+        db, db_tournament.id, include_dropped=include_dropped
+    )
 
 
 @router.delete("/{code}/participants/{participant_id}", status_code=204)
@@ -58,6 +64,20 @@ async def admin_remove_participant(
 
     await services.remove_participant(db, db_tournament, code, participant_id)
     return None
+
+
+@router.post(
+    "/{code}/participants/{participant_id}/undrop",
+    response_model=schemas.ParticipantResponse,
+)
+async def admin_undrop_participant(
+    code: str, participant_id: int, db: Session = Depends(get_db)
+):
+    db_tournament = get_tournament_by_code(db, code)
+    if not db_tournament:
+        raise HTTPException(status_code=404, detail="Tournament not found")
+
+    return await services.undrop_participant(db, db_tournament, code, participant_id)
 
 
 @router.get(

--- a/backend/app/api/participants/schemas.py
+++ b/backend/app/api/participants/schemas.py
@@ -22,6 +22,8 @@ class ParticipantResponse(ParticipantBase):
     id: int
     tournament_id: int
     points: int
+    is_active: bool = True
+    dropped_round: int | None = None
     pokemon_1: str | None = None
     pokemon_2: str | None = None
     rank: int = 0

--- a/backend/app/api/participants/schemas.py
+++ b/backend/app/api/participants/schemas.py
@@ -22,8 +22,8 @@ class ParticipantResponse(ParticipantBase):
     id: int
     tournament_id: int
     points: int
-    is_active: bool = True
-    dropped_round: int | None = None
+    is_active: bool
+    dropped_round: int | None
     pokemon_1: str | None = None
     pokemon_2: str | None = None
     rank: int = 0

--- a/backend/app/api/participants/services.py
+++ b/backend/app/api/participants/services.py
@@ -57,9 +57,37 @@ async def remove_participant(
     )
 
 
-def get_participants(db: Session, tournament_id: int) -> List[models.Participant]:
+async def undrop_participant(
+    db: Session, tournament: Tournament, code: str, participant_id: int
+) -> models.Participant:
     participant_repo = SqlAlchemyParticipantRepository(db)
-    return participant_repo.get_by_tournament(tournament_id)
+    match_repo = SqlAlchemyMatchRepository(db)
+    participant = use_cases.undrop_participant(
+        participants=participant_repo,
+        matches=match_repo,
+        tournament=tournament,
+        participant_id=participant_id,
+    )
+    await manager.broadcast(
+        code,
+        {
+            "event": "participant_undropped",
+            "data": {
+                "id": participant.id,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+        },
+    )
+    return participant
+
+
+def get_participants(
+    db: Session, tournament_id: int, include_dropped: bool = False
+) -> List[models.Participant]:
+    participant_repo = SqlAlchemyParticipantRepository(db)
+    return participant_repo.get_by_tournament(
+        tournament_id, include_inactive=include_dropped
+    )
 
 
 def get_potential_pairings(

--- a/backend/app/api/participants/use_cases.py
+++ b/backend/app/api/participants/use_cases.py
@@ -74,6 +74,33 @@ def remove_participant(
     participants.delete(participant)
 
 
+def undrop_participant(
+    participants: ParticipantRepositoryPort,
+    matches: MatchRepositoryPort,
+    tournament: Tournament,
+    participant_id: int,
+) -> Participant:
+    assert_tournament_can_accept_changes(tournament)
+    participant = participants.get_by_id(participant_id)
+    if not participant or participant.tournament_id != tournament.id:
+        raise HTTPException(status_code=404, detail="Participant not found")
+    if participant.is_active:
+        return participant
+
+    current_round = _get_current_round(matches, tournament.id)
+    dropped_round = participant.dropped_round
+    if dropped_round is None or current_round != dropped_round:
+        raise HTTPException(
+            status_code=400,
+            detail="Participants can only be undropped in the round they were dropped",
+        )
+
+    participant.is_active = True
+    participant.dropped_round = None
+    participants.save(participant)
+    return participant
+
+
 def _get_current_round(matches: MatchRepositoryPort, tournament_id: int) -> int:
     tournament_matches = matches.get_by_tournament(tournament_id)
     if not tournament_matches:

--- a/backend/app/api/participants/use_cases.py
+++ b/backend/app/api/participants/use_cases.py
@@ -85,7 +85,7 @@ def undrop_participant(
     if not participant or participant.tournament_id != tournament.id:
         raise HTTPException(status_code=404, detail="Participant not found")
     if participant.is_active:
-        return participant
+        raise HTTPException(status_code=400, detail="Participant is already active")
 
     current_round = _get_current_round(matches, tournament.id)
     dropped_round = participant.dropped_round

--- a/backend/app/api/tournaments/standings.py
+++ b/backend/app/api/tournaments/standings.py
@@ -30,6 +30,8 @@ def calculate_standings(db: Session, tournament_id: int) -> List[ParticipantResp
             "id": p.id,
             "name": p.name,
             "tournament_id": p.tournament_id,
+            "is_active": p.is_active,
+            "dropped_round": p.dropped_round,
             "pokemon_1": p.pokemon_1,
             "pokemon_2": p.pokemon_2,
             "points": 0,

--- a/backend/app/application/ports.py
+++ b/backend/app/application/ports.py
@@ -27,7 +27,9 @@ class TournamentRepositoryPort(Protocol):
 
 
 class ParticipantRepositoryPort(Protocol):
-    def get_by_tournament(self, tournament_id: int) -> List[Participant]: ...
+    def get_by_tournament(
+        self, tournament_id: int, include_inactive: bool = False
+    ) -> List[Participant]: ...
 
     def get_by_id(self, participant_id: int) -> Optional[Participant]: ...
 

--- a/backend/tests/test_admin_participant_actions.py
+++ b/backend/tests/test_admin_participant_actions.py
@@ -134,7 +134,9 @@ def test_admin_can_undrop_only_in_drop_round(setup_db):
     assert dropped_participant["is_active"] is False
     assert dropped_participant["dropped_round"] == 1
 
-    undrop_resp = client.post(f"/tournaments/{code}/participants/{participant_id}/undrop")
+    undrop_resp = client.post(
+        f"/tournaments/{code}/participants/{participant_id}/undrop"
+    )
     assert undrop_resp.status_code == 200
     assert undrop_resp.json()["is_active"] is True
     assert undrop_resp.json()["dropped_round"] is None

--- a/backend/tests/test_admin_participant_actions.py
+++ b/backend/tests/test_admin_participant_actions.py
@@ -129,6 +129,10 @@ def test_admin_can_undrop_only_in_drop_round(setup_db):
     del_resp = client.delete(f"/tournaments/{code}/participants/{participant_id}")
     assert del_resp.status_code == 204
 
+    list_default_resp = client.get(f"/tournaments/{code}/participants")
+    default_ids = {participant["id"] for participant in list_default_resp.json()}
+    assert participant_id not in default_ids
+
     list_resp = client.get(f"/tournaments/{code}/participants?include_dropped=true")
     dropped_participant = next(p for p in list_resp.json() if p["id"] == participant_id)
     assert dropped_participant["is_active"] is False

--- a/backend/tests/test_admin_participant_actions.py
+++ b/backend/tests/test_admin_participant_actions.py
@@ -152,6 +152,22 @@ def test_admin_can_undrop_only_in_drop_round(setup_db):
     assert late_undrop_resp.status_code == 400
 
 
+def test_admin_cannot_undrop_already_active_participant(setup_db):
+    create_resp = client.post(
+        "/tournaments", json={"name": "Undrop Active Participant Tournament"}
+    )
+    code = create_resp.json()["code"]
+
+    join_resp = client.post(f"/tournaments/{code}/join", json={"name": "StillActive"})
+    participant_id = join_resp.json()["id"]
+
+    undrop_resp = client.post(
+        f"/tournaments/{code}/participants/{participant_id}/undrop"
+    )
+    assert undrop_resp.status_code == 400
+    assert undrop_resp.json()["detail"] == "Participant is already active"
+
+
 def test_removing_participants_mid_event_does_not_shrink_rounds(setup_db):
     create_resp = client.post("/tournaments", json={"name": "Stable Rounds Tournament"})
     code = create_resp.json()["code"]

--- a/backend/tests/test_admin_participant_actions.py
+++ b/backend/tests/test_admin_participant_actions.py
@@ -105,6 +105,51 @@ def test_admin_remove_participant(setup_db):
     assert join_again_resp.status_code == 200
 
 
+def test_admin_can_undrop_only_in_drop_round(setup_db):
+    create_resp = client.post("/tournaments", json={"name": "Undrop Tournament"})
+    code = create_resp.json()["code"]
+
+    join_resp = client.post(f"/tournaments/{code}/join", json={"name": "UndoMe"})
+    participant_id = join_resp.json()["id"]
+    client.post(f"/tournaments/{code}/join", json={"name": "P2"})
+    client.post(f"/tournaments/{code}/join", json={"name": "P3"})
+    client.post(f"/tournaments/{code}/join", json={"name": "P4"})
+
+    pairings_resp = client.post(f"/tournaments/{code}/pairings")
+    assert pairings_resp.status_code == 200
+    matches = client.get(f"/tournaments/{code}/matches").json()
+    round_1_matches = [match for match in matches if match["round_number"] == 1]
+    for match in round_1_matches:
+        report_resp = client.post(
+            f"/matches/{match['id']}/report",
+            json={"player1_score": 2, "player2_score": 0, "is_admin": True},
+        )
+        assert report_resp.status_code == 200
+
+    del_resp = client.delete(f"/tournaments/{code}/participants/{participant_id}")
+    assert del_resp.status_code == 204
+
+    list_resp = client.get(f"/tournaments/{code}/participants?include_dropped=true")
+    dropped_participant = next(p for p in list_resp.json() if p["id"] == participant_id)
+    assert dropped_participant["is_active"] is False
+    assert dropped_participant["dropped_round"] == 1
+
+    undrop_resp = client.post(f"/tournaments/{code}/participants/{participant_id}/undrop")
+    assert undrop_resp.status_code == 200
+    assert undrop_resp.json()["is_active"] is True
+    assert undrop_resp.json()["dropped_round"] is None
+
+    del_resp = client.delete(f"/tournaments/{code}/participants/{participant_id}")
+    assert del_resp.status_code == 204
+    pairings_resp = client.post(f"/tournaments/{code}/pairings")
+    assert pairings_resp.status_code == 200
+
+    late_undrop_resp = client.post(
+        f"/tournaments/{code}/participants/{participant_id}/undrop"
+    )
+    assert late_undrop_resp.status_code == 400
+
+
 def test_removing_participants_mid_event_does_not_shrink_rounds(setup_db):
     create_resp = client.post("/tournaments", json={"name": "Stable Rounds Tournament"})
     code = create_resp.json()["code"]

--- a/frontend/src/components/AdminDashboard.tsx
+++ b/frontend/src/components/AdminDashboard.tsx
@@ -33,6 +33,8 @@ interface Participant {
   id: number;
   name: string;
   points: number;
+  is_active?: boolean;
+  dropped_round?: number | null;
   pokemon_1?: string | null;
   pokemon_2?: string | null;
   rank?: number;
@@ -100,7 +102,7 @@ export default function AdminDashboard() {
   const fetchParticipants = useCallback(async () => {
     if (!tournament) return;
     try {
-      const response = await fetch(`${config.apiUrl}/tournaments/${tournament.code}/participants`);
+      const response = await fetch(`${config.apiUrl}/tournaments/${tournament.code}/participants?include_dropped=true`);
       if (response.ok) {
         const data = await response.json();
         setParticipants(data);
@@ -154,6 +156,7 @@ export default function AdminDashboard() {
       if (
         message.event === 'participant_joined'
         || message.event === 'participant_removed'
+        || message.event === 'participant_undropped'
         || message.event === 'match_reported'
         || message.event === 'pairings_generated'
         || message.event === 'tournament_completed'
@@ -641,6 +644,7 @@ export default function AdminDashboard() {
             <ParticipantList
               tournamentCode={tournament.code}
               participants={participants}
+              currentRound={currentRound}
               onUpdate={fetchParticipants}
             />
             <ActivityLog events={events} />

--- a/frontend/src/components/ParticipantList.test.tsx
+++ b/frontend/src/components/ParticipantList.test.tsx
@@ -35,6 +35,7 @@ describe('ParticipantList', () => {
       <ParticipantList
         tournamentCode={mockTournamentCode}
         participants={mockParticipants}
+        currentRound={1}
         onUpdate={mockOnUpdate}
       />
     );
@@ -69,6 +70,7 @@ describe('ParticipantList', () => {
       <ParticipantList
         tournamentCode={mockTournamentCode}
         participants={[]}
+        currentRound={1}
         onUpdate={mockOnUpdate}
       />
     );
@@ -113,6 +115,7 @@ describe('ParticipantList', () => {
       <ParticipantList
         tournamentCode={mockTournamentCode}
         participants={mockParticipants}
+        currentRound={1}
         onUpdate={mockOnUpdate}
       />
     );
@@ -126,6 +129,42 @@ describe('ParticipantList', () => {
         expect.objectContaining({
           method: 'DELETE'
         })
+      );
+      expect(mockOnUpdate).toHaveBeenCalled();
+    });
+  });
+
+  it('handles participant undrop in the dropped round', async () => {
+    const droppedParticipant = [{ id: 3, name: 'Dropped', points: 3, is_active: false, dropped_round: 1 }];
+
+    (fetch as any).mockImplementation((url: string, options?: { method?: string }) => {
+      if (url.includes('pokeapi.co')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ results: [] })
+        });
+      }
+      if (options?.method === 'POST' && url.includes('/undrop')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: 3, is_active: true }) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    });
+
+    render(
+      <ParticipantList
+        tournamentCode={mockTournamentCode}
+        participants={droppedParticipant}
+        currentRound={1}
+        onUpdate={mockOnUpdate}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Undrop Dropped/i }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/tournaments/${mockTournamentCode}/participants/3/undrop`),
+        expect.objectContaining({ method: 'POST' })
       );
       expect(mockOnUpdate).toHaveBeenCalled();
     });

--- a/frontend/src/components/ParticipantList.test.tsx
+++ b/frontend/src/components/ParticipantList.test.tsx
@@ -169,4 +169,30 @@ describe('ParticipantList', () => {
       expect(mockOnUpdate).toHaveBeenCalled();
     });
   });
+
+  it('disables undrop when participant was dropped in a different round', async () => {
+    const droppedParticipant = [{ id: 4, name: 'DroppedEarlier', points: 1, is_active: false, dropped_round: 1 }];
+    const fetchSpy = vi.spyOn(global, 'fetch');
+
+    render(
+      <ParticipantList
+        tournamentCode={mockTournamentCode}
+        participants={droppedParticipant}
+        currentRound={2}
+        onUpdate={mockOnUpdate}
+      />
+    );
+
+    const undropButton = screen.getByRole('button', { name: /Undrop DroppedEarlier/i });
+    await waitFor(() => {
+      expect(undropButton).toBeDisabled();
+    });
+    fireEvent.click(undropButton);
+
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining(`/tournaments/${mockTournamentCode}/participants/4/undrop`),
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(mockOnUpdate).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/ParticipantList.tsx
+++ b/frontend/src/components/ParticipantList.tsx
@@ -8,6 +8,8 @@ interface Participant {
   id: number;
   name: string;
   points: number;
+  is_active?: boolean;
+  dropped_round?: number | null;
   pokemon_1?: string | null;
   pokemon_2?: string | null;
 }
@@ -15,10 +17,11 @@ interface Participant {
 interface ParticipantListProps {
   tournamentCode: string;
   participants: Participant[];
+  currentRound: number;
   onUpdate: () => void;
 }
 
-export default function ParticipantList({ tournamentCode, participants, onUpdate }: ParticipantListProps) {
+export default function ParticipantList({ tournamentCode, participants, currentRound, onUpdate }: ParticipantListProps) {
   // ... rest of state
   const [newName, setNewName] = useState('');
   const [pokemon1, setPokemon1] = useState<string | null>(null);
@@ -70,6 +73,22 @@ export default function ParticipantList({ tournamentCode, participants, onUpdate
       });
 
       if (!response.ok) throw new Error(t('participantsRemoveFailed'));
+      onUpdate();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('commonUnexpectedError'));
+    }
+  };
+
+  const handleUndropParticipant = async (id: number) => {
+    try {
+      const response = await fetch(`${config.apiUrl}/tournaments/${tournamentCode}/participants/${id}/undrop`, {
+        method: 'POST',
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.detail || t('participantsUndropFailed'));
+      }
       onUpdate();
     } catch (err) {
       setError(err instanceof Error ? err.message : t('commonUnexpectedError'));
@@ -137,13 +156,24 @@ export default function ParticipantList({ tournamentCode, participants, onUpdate
                     <div className="text-xs text-gray-500">{p.points} {t('participantsPoints')}</div>
                   </div>
                 </div>
-                <button
-                  onClick={() => handleRemoveParticipant(p.id)}
-                  className="w-8 h-8 flex items-center justify-center text-red-400 hover:text-red-600 hover:bg-red-50 rounded-full transition opacity-100 md:opacity-80 md:group-hover:opacity-100"
-                  aria-label={`Remove ${p.name}`}
-                >
-                  &times;
-                </button>
+                {p.is_active === false ? (
+                  <button
+                    onClick={() => handleUndropParticipant(p.id)}
+                    disabled={p.dropped_round !== currentRound}
+                    className="px-2 py-1 text-xs font-semibold rounded-md border border-green-200 text-green-600 hover:bg-green-50 disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-label={`Undrop ${p.name}`}
+                  >
+                    {t('participantsUndrop')}
+                  </button>
+                ) : (
+                  <button
+                    onClick={() => handleRemoveParticipant(p.id)}
+                    className="w-8 h-8 flex items-center justify-center text-red-400 hover:text-red-600 hover:bg-red-50 rounded-full transition opacity-100 md:opacity-80 md:group-hover:opacity-100"
+                    aria-label={`Remove ${p.name}`}
+                  >
+                    &times;
+                  </button>
+                )}
               </div>
             ))
           )}

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -57,6 +57,8 @@ const MESSAGES = {
     participantsRemoveConfirm: 'Are you sure you want to remove this participant?',
     participantsAddFailed: 'Failed to add participant',
     participantsRemoveFailed: 'Failed to remove participant',
+    participantsUndrop: 'Undrop',
+    participantsUndropFailed: 'Failed to undrop participant',
 
     commonUnexpectedError: 'An unexpected error occurred',
     commonNone: 'None',
@@ -206,6 +208,8 @@ const MESSAGES = {
     participantsRemoveConfirm: 'Tem certeza que deseja remover este participante?',
     participantsAddFailed: 'Falha ao adicionar participante',
     participantsRemoveFailed: 'Falha ao remover participante',
+    participantsUndrop: 'Reativar',
+    participantsUndropFailed: 'Falha ao reativar participante',
 
     commonUnexpectedError: 'Ocorreu um erro inesperado',
     commonNone: 'Nenhum',


### PR DESCRIPTION
### Motivation

- Enable admins to reinstate (undrop) a player from the admin UI but restrict that action to the exact round the player was dropped to match tournament rules.

### Description

- Exposed participant status metadata in API responses by adding `is_active` and `dropped_round` to `ParticipantResponse` and extended the participant listing to accept `include_dropped` so dropped players are visible to the admin UI.
- Added a round-scoped undrop flow: `POST /tournaments/{code}/participants/{participant_id}/undrop` implemented across router/service/use-case layers with a websocket broadcast `participant_undropped`, and the use case enforces `current_round == dropped_round` as the allowed undrop condition.
- Updated the SQLAlchemy participant repository and application port to support returning inactive participants via `include_inactive` and adjusted callers accordingly.
- Frontend changes fetch participants with `include_dropped=true`, react to `participant_undropped` websocket events, pass the current round into `ParticipantList`, and render an `Undrop` action for dropped players that is only enabled when `dropped_round === currentRound`; i18n strings were added for the new action.

### Testing

- Ran backend unit tests for admin participant flows with `PYTHONPATH=. uv run --project backend pytest backend/tests/test_admin_participant_actions.py` and all tests passed (`4 passed`).
- Ran the relevant frontend tests with `cd frontend && npm test -- ParticipantList.test.tsx AdminDashboard.test.tsx` and both test files passed (`2 files, 13 tests` passed).
- Ran lint/type checks: `uv run --project backend ruff check backend/app backend/tests` and `cd frontend && npm run lint && npx tsc -b` and both succeeded.
- Attempted `uv run --project backend pre-commit run --all-files` which failed in this environment due to network restrictions when fetching remote pre-commit hooks (CONNECT tunnel 403), unrelated to code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7bc8845b8832ba29ef67eff694534)